### PR TITLE
Feature/error codes #22

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/api/AttendanceApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/AttendanceApiController.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.api;
 
+import gdsc.binaryho.imhere.exception.ImhereException;
 import gdsc.binaryho.imhere.mapper.dtos.AttendanceDto;
 import gdsc.binaryho.imhere.mapper.requests.AttendanceRequest;
 import gdsc.binaryho.imhere.service.AttendanceService;
@@ -33,9 +34,9 @@ public class AttendanceApiController {
         try {
             attendanceService.takeAttendance(attendanceRequest, lectureId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
-        } catch (Exception e) {
+        } catch (ImhereException e) {
             e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/api/AttendanceApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/AttendanceApiController.java
@@ -7,6 +7,7 @@ import gdsc.binaryho.imhere.service.AttendanceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Log4j2
 @Tag(name = "Attendance", description = "출석 기능 관련 API입니다.")
 @RestController
 @RequestMapping("/api/attendance")
@@ -35,7 +37,7 @@ public class AttendanceApiController {
             attendanceService.takeAttendance(attendanceRequest, lectureId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
         } catch (ImhereException e) {
-            e.printStackTrace();
+            log.info("[출석 시도 예외 발생] : ", e);
             return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
@@ -49,7 +51,8 @@ public class AttendanceApiController {
     @Operation(summary = "특정 강의의 지정 날짜 출석 리스트를 가져오는 API")
     @GetMapping("/{lecture_id}/{day_milliseconds}")
     public AttendanceDto getTodayAttendance(@PathVariable("lecture_id") Long lectureId,
-        @Parameter(description = "js Date 객체의 getTime 메서드로 만든 milliseconds 현재 시각") @PathVariable("day_milliseconds") Long milliseconds) {
+        @Parameter(description = "js Date 객체의 getTime 메서드로 만든 milliseconds 현재 시각")
+        @PathVariable("day_milliseconds") Long milliseconds) {
         return attendanceService.getDayAttendances(lectureId, milliseconds);
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/api/EnrollmentApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/EnrollmentApiController.java
@@ -5,6 +5,7 @@ import gdsc.binaryho.imhere.mapper.dtos.EnrollmentInfoDto;
 import gdsc.binaryho.imhere.service.EnrollmentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Log4j2
 @Tag(name = "Enrollment", description = "수강 신청 관련 API입니다.")
 @RestController
 @RequestMapping("/api/enrollment")
@@ -39,7 +41,7 @@ public class EnrollmentApiController {
             enrollmentService.approveStudents(lectureId, studentId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
         } catch (ImhereException e) {
-            e.printStackTrace();
+            log.info("[수강신청 승인 ERROR] : " + e);
             return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
@@ -52,7 +54,6 @@ public class EnrollmentApiController {
             enrollmentService.rejectStudents(lectureId, studentId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
         } catch (ImhereException e) {
-            e.printStackTrace();
             return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
@@ -65,7 +66,6 @@ public class EnrollmentApiController {
             enrollmentService.requestEnrollment(lectureId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
         } catch (ImhereException e) {
-            e.printStackTrace();
             return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }

--- a/src/main/java/gdsc/binaryho/imhere/api/EnrollmentApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/EnrollmentApiController.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.api;
 
+import gdsc.binaryho.imhere.exception.ImhereException;
 import gdsc.binaryho.imhere.mapper.dtos.EnrollmentInfoDto;
 import gdsc.binaryho.imhere.service.EnrollmentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,9 +38,9 @@ public class EnrollmentApiController {
         try {
             enrollmentService.approveStudents(lectureId, studentId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
-        } catch (Exception e) {
+        } catch (ImhereException e) {
             e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 
@@ -50,9 +51,9 @@ public class EnrollmentApiController {
         try {
             enrollmentService.rejectStudents(lectureId, studentId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
-        } catch (Exception e) {
+        } catch (ImhereException e) {
             e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 
@@ -63,9 +64,9 @@ public class EnrollmentApiController {
         try {
             enrollmentService.requestEnrollment(lectureId);
             return ResponseEntity.ok(HttpStatus.OK.getReasonPhrase());
-        } catch (Exception e) {
+        } catch (ImhereException e) {
             e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/api/LectureApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/LectureApiController.java
@@ -3,6 +3,7 @@ package gdsc.binaryho.imhere.api;
 import gdsc.binaryho.imhere.domain.lecture.Lecture;
 import gdsc.binaryho.imhere.domain.lecture.LectureRepository;
 import gdsc.binaryho.imhere.domain.lecture.LectureState;
+import gdsc.binaryho.imhere.exception.ImhereException;
 import gdsc.binaryho.imhere.mapper.dtos.AttendanceNumberDto;
 import gdsc.binaryho.imhere.mapper.dtos.LectureDto;
 import gdsc.binaryho.imhere.mapper.requests.LectureCreateRequest;
@@ -71,9 +72,9 @@ public class LectureApiController {
         try {
             lectureService.createLecture(request);
             return ResponseEntity.ok(HttpStatus.OK.toString());
-        } catch (RuntimeException error) {
+        } catch (ImhereException error) {
             error.printStackTrace();
-            return new ResponseEntity<>(error.getMessage(), HttpStatus.NOT_FOUND);
+            return ResponseEntity.status(error.getErrorCode().getCode()).build();
         }
     }
 
@@ -83,9 +84,9 @@ public class LectureApiController {
         try {
             int attendanceNumber = lectureService.openLectureAndGetAttendanceNumber(lectureId);
             return ResponseEntity.ok(new AttendanceNumberDto(attendanceNumber));
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (ImhereException error) {
+            error.printStackTrace();
+            return ResponseEntity.status(error.getErrorCode().getCode()).build();
         }
     }
 
@@ -95,9 +96,9 @@ public class LectureApiController {
         try {
             lectureService.closeLecture(lecture_id);
             return ResponseEntity.ok(HttpStatus.OK.toString());
-        } catch (RuntimeException error) {
+        } catch (ImhereException error) {
             error.printStackTrace();
-            return new ResponseEntity<>(error.getMessage(), HttpStatus.NOT_FOUND);
+            return ResponseEntity.status(error.getErrorCode().getCode()).build();
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/api/LectureApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/LectureApiController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Log4j2
 @Tag(name = "Lecture", description = "강의 관련 API입니다.")
 @RestController
 @RequestMapping("/api/lectures")
@@ -73,7 +75,6 @@ public class LectureApiController {
             lectureService.createLecture(request);
             return ResponseEntity.ok(HttpStatus.OK.toString());
         } catch (ImhereException error) {
-            error.printStackTrace();
             return ResponseEntity.status(error.getErrorCode().getCode()).build();
         }
     }
@@ -84,9 +85,9 @@ public class LectureApiController {
         try {
             int attendanceNumber = lectureService.openLectureAndGetAttendanceNumber(lectureId);
             return ResponseEntity.ok(new AttendanceNumberDto(attendanceNumber));
-        } catch (ImhereException error) {
-            error.printStackTrace();
-            return ResponseEntity.status(error.getErrorCode().getCode()).build();
+        } catch (ImhereException e) {
+            log.error("[강의 OPEN ERROR] : " + e);
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 
@@ -96,9 +97,8 @@ public class LectureApiController {
         try {
             lectureService.closeLecture(lecture_id);
             return ResponseEntity.ok(HttpStatus.OK.toString());
-        } catch (ImhereException error) {
-            error.printStackTrace();
-            return ResponseEntity.status(error.getErrorCode().getCode()).build();
+        } catch (ImhereException e) {
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/api/MemberApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/MemberApiController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.UnsupportedEncodingException;
 import javax.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailException;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Log4j2
 @Tag(name = "Member", description = "유저 계정 관련 API입니다.")
 @RestController
 @RequestMapping("/member")
@@ -36,7 +38,11 @@ public class MemberApiController {
                 signUpRequest.getPassword());
             return ResponseEntity.ok(HttpStatus.OK.toString());
         } catch (ImhereException e) {
-            e.printStackTrace();
+            log.info("[회원가입 에러] 제출 email : {}, name : {}, password : {}\n -> 사유 {}",
+                () -> signUpRequest.getUnivId(),
+                () -> signUpRequest.getName(),
+                () -> signUpRequest.getPassword(),
+                () -> e.getErrorCode().getMessage());
             return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
@@ -48,7 +54,7 @@ public class MemberApiController {
             emailService.sendMailAndGetVerificationCode(email);
             return ResponseEntity.ok(HttpStatus.OK.toString());
         } catch (MailException | MessagingException | UnsupportedEncodingException error) {
-            error.printStackTrace();
+            log.info("[이메일 인증 번호 전송 에러] email : {}", email);
             return new ResponseEntity<>(error.getMessage(), HttpStatus.NOT_FOUND);
         }
     }
@@ -60,6 +66,7 @@ public class MemberApiController {
         try {
             return emailService.verifyCode(email, verificationCode);
         } catch (RuntimeException e) {
+            log.info("[이메일 인증 번호 불일치] email : {}, 제출 코드 {}", email, verificationCode);
             return false;
         }
     }

--- a/src/main/java/gdsc/binaryho/imhere/api/MemberApiController.java
+++ b/src/main/java/gdsc/binaryho/imhere/api/MemberApiController.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.api;
 
+import gdsc.binaryho.imhere.exception.ImhereException;
 import gdsc.binaryho.imhere.mapper.requests.SignUpRequest;
 import gdsc.binaryho.imhere.service.EmailService;
 import gdsc.binaryho.imhere.service.MemberService;
@@ -34,9 +35,9 @@ public class MemberApiController {
             memberService.signUp(signUpRequest.getUnivId(), signUpRequest.getName(),
                 signUpRequest.getPassword());
             return ResponseEntity.ok(HttpStatus.OK.toString());
-        } catch (RuntimeException error) {
-            error.printStackTrace();
-            return new ResponseEntity<>(error.getMessage(), HttpStatus.NOT_FOUND);
+        } catch (ImhereException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(e.getErrorCode().getCode()).build();
         }
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package gdsc.binaryho.imhere.mapper.response;
+package gdsc.binaryho.imhere.exception;
 
 import lombok.Getter;
 
@@ -24,7 +24,12 @@ public enum ErrorCode {
     ENROLLMENT_NOT_APPROVED(463, "수강신청 승인되지 않음"),
 
     ATTENDANCE_NUMBER_INCORRECT(470, "출석 번호 불일치"),
-    ATTENDANCE_TIME_EXCEEDED(471, "출석 가능 시간 초과");
+    ATTENDANCE_TIME_EXCEEDED(471, "출석 가능 시간 초과"),
+
+    REQUEST_MEMBER_ID_MISMATCH(490, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
+    PERMISSION_DENIED(491, "유저가 권한 이상의 Request를 보냈습니다. (악의적 요청)"),
+
+    ;
 
     private int code;
     private String message;

--- a/src/main/java/gdsc/binaryho/imhere/exception/ImhereException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ImhereException.java
@@ -1,0 +1,11 @@
+package gdsc.binaryho.imhere.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImhereException extends RuntimeException {
+
+    private ErrorCode errorCode;
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/RequestFormatMismatchException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/RequestFormatMismatchException.java
@@ -1,0 +1,10 @@
+package gdsc.binaryho.imhere.exception;
+
+public class RequestFormatMismatchException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new RequestFormatMismatchException();
+
+    private RequestFormatMismatchException() {
+        super(ErrorCode.REQUEST_FORMAT_MISMATCH);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/attendance/AttendanceNumberIncorrectException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/attendance/AttendanceNumberIncorrectException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.attendance;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class AttendanceNumberIncorrectException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new AttendanceNumberIncorrectException();
+
+    private AttendanceNumberIncorrectException() {
+        super(ErrorCode.ATTENDANCE_NUMBER_INCORRECT);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/attendance/AttendanceTimeExceededException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/attendance/AttendanceTimeExceededException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.attendance;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class AttendanceTimeExceededException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new AttendanceTimeExceededException();
+
+    private AttendanceTimeExceededException() {
+        super(ErrorCode.ATTENDANCE_TIME_EXCEEDED);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentDuplicatedException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentDuplicatedException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.enrollment;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class EnrollmentDuplicatedException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new EnrollmentDuplicatedException();
+
+    private EnrollmentDuplicatedException() {
+        super(ErrorCode.ENROLLMENT_DUPLICATED);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentNotApprovedException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentNotApprovedException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.enrollment;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class EnrollmentNotApprovedException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new EnrollmentNotApprovedException();
+
+    private EnrollmentNotApprovedException() {
+        super(ErrorCode.ENROLLMENT_NOT_APPROVED);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentNotFoundException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/enrollment/EnrollmentNotFoundException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.enrollment;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class EnrollmentNotFoundException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new EnrollmentNotFoundException();
+
+    private EnrollmentNotFoundException() {
+        super(ErrorCode.ENROLLMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/lecture/LectureNotFoundException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/lecture/LectureNotFoundException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.lecture;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class LectureNotFoundException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new LectureNotFoundException();
+
+    private LectureNotFoundException() {
+        super(ErrorCode.LECTURE_NOT_FOUND);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/lecture/LectureNotOpenException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/lecture/LectureNotOpenException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.lecture;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class LectureNotOpenException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new LectureNotOpenException();
+
+    private LectureNotOpenException() {
+        super(ErrorCode.LECTURE_NOT_OPEN);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/EmailDuplicatedException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/EmailDuplicatedException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class EmailDuplicatedException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new EmailDuplicatedException();
+
+    private EmailDuplicatedException() {
+        super(ErrorCode.EMAIL_DUPLICATED);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/EmailFormatMismatchException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/EmailFormatMismatchException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class EmailFormatMismatchException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new EmailFormatMismatchException();
+
+    private EmailFormatMismatchException() {
+        super(ErrorCode.EMAIL_FORMAT_MISMATCH);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/MemberNotFoundException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/MemberNotFoundException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class MemberNotFoundException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new MemberNotFoundException();
+
+    private MemberNotFoundException() {
+        super(ErrorCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/PasswordFormatMismatchException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/PasswordFormatMismatchException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordFormatMismatchException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordFormatMismatchException();
+
+    private PasswordFormatMismatchException() {
+        super(ErrorCode.PASSWORD_FORMAT_MISMATCH);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/PasswordIncorrectException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/PasswordIncorrectException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordIncorrectException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordIncorrectException();
+
+    private PasswordIncorrectException() {
+        super(ErrorCode.PASSWORD_INCORRECT);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/PermissionDeniedException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/PermissionDeniedException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PermissionDeniedException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PermissionDeniedException();
+
+    private PermissionDeniedException() {
+        super(ErrorCode.PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/member/RequestMemberIdMismatchException.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/member/RequestMemberIdMismatchException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.exception.member;
+
+import gdsc.binaryho.imhere.exception.ErrorCode;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class RequestMemberIdMismatchException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new RequestMemberIdMismatchException();
+
+    private RequestMemberIdMismatchException() {
+        super(ErrorCode.REQUEST_MEMBER_ID_MISMATCH);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/mapper/response/ErrorCode.java
+++ b/src/main/java/gdsc/binaryho/imhere/mapper/response/ErrorCode.java
@@ -1,0 +1,36 @@
+package gdsc.binaryho.imhere.mapper.response;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    BAD_REQUEST(400, "잘못된 요청입니다."),
+    FORBIDDEN(403, "접근 권한이 없습니다."),
+    NOT_FOUND(404, "Not Found"),
+
+    MEMBER_NOT_FOUND(440, "로그인 회원 정보가 없습니다."),
+    PASSWORD_INCORRECT(441, "로그인 회원 비밀번호가 불일치합니다."),
+    EMAIL_DUPLICATED(443, "이미 가입된 Email 입니다."),
+    EMAIL_FORMAT_MISMATCH(445, "형식에 맞는 이메일을 입력하세요."),
+    PASSWORD_FORMAT_MISMATCH(446, "형식에 맞는 비밀번호를 입력하세요."),
+    REQUEST_FORMAT_MISMATCH(447, "Request 형식이 맞지 않습니다."),
+
+    LECTURE_NOT_FOUND(450, "강의 정보가 없습니다."),
+    LECTURE_NOT_OPEN(451, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
+
+    ENROLLMENT_NOT_FOUND(461, "수강신청 정보 없음"),
+    ENROLLMENT_DUPLICATED(462, "수강신청 중복 요청"),
+    ENROLLMENT_NOT_APPROVED(463, "수강신청 승인되지 않음"),
+
+    ATTENDANCE_NUMBER_INCORRECT(470, "출석 번호 불일치"),
+    ATTENDANCE_TIME_EXCEEDED(471, "출석 가능 시간 초과");
+
+    private int code;
+    private String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/service/AuthenticationHelper.java
+++ b/src/main/java/gdsc/binaryho/imhere/service/AuthenticationHelper.java
@@ -3,7 +3,9 @@ package gdsc.binaryho.imhere.service;
 import gdsc.binaryho.imhere.config.auth.PrincipalDetails;
 import gdsc.binaryho.imhere.domain.member.Member;
 import gdsc.binaryho.imhere.domain.member.Role;
-import org.springframework.security.access.AccessDeniedException;
+import gdsc.binaryho.imhere.exception.member.MemberNotFoundException;
+import gdsc.binaryho.imhere.exception.member.PermissionDeniedException;
+import gdsc.binaryho.imhere.exception.member.RequestMemberIdMismatchException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -22,25 +24,25 @@ public class AuthenticationHelper {
 
     public void verifyRequestMemberLogInMember(Long requestId) {
         if (!requestId.equals(getCurrentMember().getId())) {
-            throw new AccessDeniedException("Access Denied requestId : " + requestId);
+            throw RequestMemberIdMismatchException.EXCEPTION;
         }
     }
 
     public void verifyMemberHasAdminRole() {
         if (!getCurrentMember().getRole().equals(Role.ADMIN)) {
-            throw new AccessDeniedException("Access Denied : User has not role");
+            throw PermissionDeniedException.EXCEPTION;
         }
     }
 
     private void validateAuthenticationNotNull(Authentication authentication) {
         if (authentication == null) {
-            throw new IllegalStateException("No Authentication Member");
+            throw MemberNotFoundException.EXCEPTION;
         }
     }
 
     private void validateAuthenticated(Authentication authentication) {
         if (!authentication.isAuthenticated()) {
-            throw new AccessDeniedException("UnAuthentication Exception");
+            throw MemberNotFoundException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/service/AuthenticationHelper.java
+++ b/src/main/java/gdsc/binaryho/imhere/service/AuthenticationHelper.java
@@ -6,10 +6,12 @@ import gdsc.binaryho.imhere.domain.member.Role;
 import gdsc.binaryho.imhere.exception.member.MemberNotFoundException;
 import gdsc.binaryho.imhere.exception.member.PermissionDeniedException;
 import gdsc.binaryho.imhere.exception.member.RequestMemberIdMismatchException;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+@Log4j2
 @Component
 public class AuthenticationHelper {
 

--- a/src/main/java/gdsc/binaryho/imhere/service/EmailService.java
+++ b/src/main/java/gdsc/binaryho/imhere/service/EmailService.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.service;
 
+import gdsc.binaryho.imhere.exception.member.EmailFormatMismatchException;
 import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 import java.util.UUID;
@@ -80,7 +81,7 @@ public class EmailService {
 
     private void validateEmailForm(String recipient) {
         if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
-            throw new IllegalArgumentException();
+            throw EmailFormatMismatchException.EXCEPTION;
         }
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/service/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/service/LectureService.java
@@ -7,6 +7,7 @@ import gdsc.binaryho.imhere.domain.lecture.Lecture;
 import gdsc.binaryho.imhere.domain.lecture.LectureRepository;
 import gdsc.binaryho.imhere.domain.lecture.LectureState;
 import gdsc.binaryho.imhere.domain.member.Member;
+import gdsc.binaryho.imhere.exception.lecture.LectureNotFoundException;
 import gdsc.binaryho.imhere.mapper.dtos.LectureDto;
 import gdsc.binaryho.imhere.mapper.requests.LectureCreateRequest;
 import java.util.List;
@@ -72,7 +73,8 @@ public class LectureService {
 
     @Transactional
     public int openLectureAndGetAttendanceNumber(Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId).orElseThrow();
+        Lecture lecture = lectureRepository.findById(lectureId)
+            .orElseThrow(() -> LectureNotFoundException.EXCEPTION);
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.OPEN);
@@ -93,7 +95,8 @@ public class LectureService {
 
     @Transactional
     public void closeLecture(Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId).orElseThrow();
+        Lecture lecture = lectureRepository.findById(lectureId)
+            .orElseThrow(() -> LectureNotFoundException.EXCEPTION);
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.CLOSED);

--- a/src/main/java/gdsc/binaryho/imhere/service/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/service/LectureService.java
@@ -11,6 +11,7 @@ import gdsc.binaryho.imhere.exception.lecture.LectureNotFoundException;
 import gdsc.binaryho.imhere.mapper.dtos.LectureDto;
 import gdsc.binaryho.imhere.mapper.requests.LectureCreateRequest;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.transaction.Transactional;
@@ -43,7 +44,8 @@ public class LectureService {
     public List<Lecture> getStudentLectures() {
         Member currentStudent = authenticationHelper.getCurrentMember();
         List<EnrollmentInfo> enrollmentInfos = enrollmentInfoRepository
-            .findAllByMemberIdAndEnrollmentState(currentStudent.getId(), EnrollmentState.APPROVAL);
+            .findAllByMemberIdAndEnrollmentState(
+                currentStudent.getId(), EnrollmentState.APPROVAL);
 
         return getLectures(enrollmentInfos);
     }
@@ -51,7 +53,8 @@ public class LectureService {
     public List<Lecture> getStudentOpenLectures() {
         Member currentStudent = authenticationHelper.getCurrentMember();
         List<EnrollmentInfo> enrollmentInfos = enrollmentInfoRepository
-            .findAllByMemberIdAndLecture_LectureStateAndEnrollmentState(currentStudent.getId(), LectureState.OPEN, EnrollmentState.APPROVAL);
+            .findAllByMemberIdAndLecture_LectureStateAndEnrollmentState(
+                currentStudent.getId(), LectureState.OPEN, EnrollmentState.APPROVAL);
 
         return getLectures(enrollmentInfos);
     }
@@ -65,16 +68,21 @@ public class LectureService {
     public List<LectureDto> getOwnedLectures() {
         Member currentLecturer = authenticationHelper.getCurrentMember();
         List<Lecture> lectures = lectureRepository.findAllByMemberId(currentLecturer.getId());
-        return lectures.stream().map(lecture ->
-            LectureDto.createLectureDtoWithEnrollmentInfo(lecture,
-                enrollmentInfoRepository.findAllByLectureAndEnrollmentState(lecture, EnrollmentState.APPROVAL))
+        return lectures.stream()
+            .map(lecture ->
+                LectureDto.createLectureDtoWithEnrollmentInfo(lecture,
+                    enrollmentInfoRepository
+                        .findAllByLectureAndEnrollmentState(lecture, EnrollmentState.APPROVAL))
         ).collect(Collectors.toList());
     }
 
     @Transactional
     public int openLectureAndGetAttendanceNumber(Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId)
-            .orElseThrow(() -> LectureNotFoundException.EXCEPTION);
+        Optional<Lecture> findLecture = lectureRepository.findById(lectureId);
+
+        validateLectureNonNull(findLecture);
+
+        Lecture lecture = findLecture.get();
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.OPEN);
@@ -95,8 +103,11 @@ public class LectureService {
 
     @Transactional
     public void closeLecture(Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId)
-            .orElseThrow(() -> LectureNotFoundException.EXCEPTION);
+        Optional<Lecture> findLecture = lectureRepository.findById(lectureId);
+
+        validateLectureNonNull(findLecture);
+
+        Lecture lecture = findLecture.get();
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.CLOSED);
@@ -108,5 +119,11 @@ public class LectureService {
     private Integer generateRandomNumber() {
         int rangeSize = RANDOM_NUMBER_END - RANDOM_NUMBER_START + 1;
         return (int) (Math.random() * (rangeSize)) + RANDOM_NUMBER_START;
+    }
+
+    private void validateLectureNonNull(Optional<Lecture> findLecture) {
+        if (findLecture.isEmpty()) {
+            throw LectureNotFoundException.EXCEPTION;
+        }
     }
 }


### PR DESCRIPTION
이슈 -> #22 

클라이언트에게 예외 발생 상황에 대한 더 자세한 정보를 제공하기 위해
Custom Exception들을 구현하고,
Exception들에 대한 Error Code와 이유 메시지를 갖는 Enum 객체를 구현했다.

원래는 성공 여부, Http Status, reson을 가진 Enum을 만들어 사용하고 싶었다.
그리고 응답 객체가 위 Enum을 필드로 가지게 하고 싶었다. 
성공 응답은 Enum객체와 T result, 실패 응답은 Enum 객체만을 갖게 하는 방식으로 가고 싶었다.

그러나 성공 여부를 포함한 시점에서, 성공-실패 두 경우를 모두 표현한 공통 응답 객체가 되어야 했고,
자연스럽게 ResponseInfo와 같은 이름을 붙여주어야만 했다.

문제는, 직접 만든 커스텀 ImhereErorr 객체가 ResponseInfo라는 객체를 가지고 있는게 너무 어색하게 느껴졌다.
차라리 Error Code나 Error Info라는 객체를 갖는게 적절해 보였다.
그래서 그냥 성공 여부를 제외한, status number와 reson만을 가진 Error Info라는 객체를 만들었다.

그리고 추상 응답 클래스를 만든 다음, Http Status Number, reason를 필드로 가진 객체를 만들 예정이다.
성공 응답의 경우 Status Number = 200, reason = "응답 성공" 과 같은 필드 값을 강제로 갖게 하고,
T 타입 result를 갖게 할 예정이다.
그리고 실패 응답의 경우 Enum을 입력으로 받아 Enum의 status number와 reason을 받아 직접 객체 필드에 할당할 것이다.