### PR TITLE
Feature/error codes #22

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
@@ -8,25 +8,25 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 440, "로그인 회원 정보가 없습니다."),
-    PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, 441, "로그인 회원 비밀번호가 불일치합니다."),
-    EMAIL_DUPLICATED(HttpStatus.CONFLICT, 443, "이미 가입된 Email 입니다."),
-    EMAIL_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 445, "형식에 맞는 이메일을 입력하세요."),
-    PASSWORD_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 446, "형식에 맞는 비밀번호를 입력하세요."),
-    REQUEST_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 447, "요청 형식이 맞지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 1001, "로그인 회원 정보가 없습니다."),
+    PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, 1002, "로그인 회원 비밀번호가 불일치합니다."),
+    EMAIL_DUPLICATED(HttpStatus.CONFLICT, 1003, "이미 가입된 Email 입니다."),
+    EMAIL_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1004, "형식에 맞는 이메일을 입력하세요."),
+    PASSWORD_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1005, "형식에 맞는 비밀번호를 입력하세요."),
+    REQUEST_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1006, "요청 형식이 맞지 않습니다."),
 
-    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 450, "강의 정보가 없습니다."),
-    LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 451, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "강의 정보가 없습니다."),
+    LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 2002, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
 
-    ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 461, "수강신청 정보 없음"),
-    ENROLLMENT_DUPLICATED(HttpStatus.CONFLICT, 462, "수강신청 중복 요청"),
-    ENROLLMENT_NOT_APPROVED(HttpStatus.FORBIDDEN, 463, "수강신청 승인되지 않음"),
+    ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "수강신청 정보 없음"),
+    ENROLLMENT_DUPLICATED(HttpStatus.CONFLICT, 3002, "수강신청 중복 요청"),
+    ENROLLMENT_NOT_APPROVED(HttpStatus.FORBIDDEN, 3003, "수강신청 승인되지 않음"),
 
-    ATTENDANCE_NUMBER_INCORRECT(HttpStatus.BAD_REQUEST, 470, "출석 번호 불일치"),
-    ATTENDANCE_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, 471, "출석 가능 시간 초과"),
+    ATTENDANCE_NUMBER_INCORRECT(HttpStatus.BAD_REQUEST, 4001, "출석 번호 불일치"),
+    ATTENDANCE_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, 4002, "출석 가능 시간 초과"),
 
-    REQUEST_MEMBER_ID_MISMATCH(HttpStatus.BAD_REQUEST, 490, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, 491, "유저가 권한이 없는 요청을 보냈습니다. (악의적 요청)"),
+    REQUEST_MEMBER_ID_MISMATCH(HttpStatus.BAD_REQUEST, 9001, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, 9002, "유저가 권한이 없는 요청을 보냈습니다. (악의적 요청)"),
 
     ;
 

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorCode.java
@@ -1,41 +1,36 @@
 package gdsc.binaryho.imhere.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
 
-    BAD_REQUEST(400, "잘못된 요청입니다."),
-    FORBIDDEN(403, "접근 권한이 없습니다."),
-    NOT_FOUND(404, "Not Found"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 440, "로그인 회원 정보가 없습니다."),
+    PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, 441, "로그인 회원 비밀번호가 불일치합니다."),
+    EMAIL_DUPLICATED(HttpStatus.CONFLICT, 443, "이미 가입된 Email 입니다."),
+    EMAIL_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 445, "형식에 맞는 이메일을 입력하세요."),
+    PASSWORD_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 446, "형식에 맞는 비밀번호를 입력하세요."),
+    REQUEST_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 447, "요청 형식이 맞지 않습니다."),
 
-    MEMBER_NOT_FOUND(440, "로그인 회원 정보가 없습니다."),
-    PASSWORD_INCORRECT(441, "로그인 회원 비밀번호가 불일치합니다."),
-    EMAIL_DUPLICATED(443, "이미 가입된 Email 입니다."),
-    EMAIL_FORMAT_MISMATCH(445, "형식에 맞는 이메일을 입력하세요."),
-    PASSWORD_FORMAT_MISMATCH(446, "형식에 맞는 비밀번호를 입력하세요."),
-    REQUEST_FORMAT_MISMATCH(447, "Request 형식이 맞지 않습니다."),
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 450, "강의 정보가 없습니다."),
+    LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 451, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
 
-    LECTURE_NOT_FOUND(450, "강의 정보가 없습니다."),
-    LECTURE_NOT_OPEN(451, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
+    ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, 461, "수강신청 정보 없음"),
+    ENROLLMENT_DUPLICATED(HttpStatus.CONFLICT, 462, "수강신청 중복 요청"),
+    ENROLLMENT_NOT_APPROVED(HttpStatus.FORBIDDEN, 463, "수강신청 승인되지 않음"),
 
-    ENROLLMENT_NOT_FOUND(461, "수강신청 정보 없음"),
-    ENROLLMENT_DUPLICATED(462, "수강신청 중복 요청"),
-    ENROLLMENT_NOT_APPROVED(463, "수강신청 승인되지 않음"),
+    ATTENDANCE_NUMBER_INCORRECT(HttpStatus.BAD_REQUEST, 470, "출석 번호 불일치"),
+    ATTENDANCE_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, 471, "출석 가능 시간 초과"),
 
-    ATTENDANCE_NUMBER_INCORRECT(470, "출석 번호 불일치"),
-    ATTENDANCE_TIME_EXCEEDED(471, "출석 가능 시간 초과"),
-
-    REQUEST_MEMBER_ID_MISMATCH(490, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
-    PERMISSION_DENIED(491, "유저가 권한 이상의 Request를 보냈습니다. (악의적 요청)"),
+    REQUEST_MEMBER_ID_MISMATCH(HttpStatus.BAD_REQUEST, 490, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, 491, "유저가 권한이 없는 요청을 보냈습니다. (악의적 요청)"),
 
     ;
 
-    private int code;
-    private String message;
-
-    ErrorCode(int code, String message) {
-        this.code = code;
-        this.message = message;
-    }
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
 }


### PR DESCRIPTION
여러 프로젝트들을 살펴보며 공부한 결과 
Enum 자체가 HttpStatus를 가지고 ResponseEntity를 만들 때 직접 status로 넣어주는 모습이 더 좋아 보였다.

그래서 ErrorCode Enum에 HttpStatus 필드를 추가해주었고,
도중에 기존 100번대 숫자들로 작성했던 커스텀 Error Code도 아예 햇갈릴 일 없도록 1000번대도 바꾸어 주었다.
100번대로 작성하면서, 기존에 있는 Http Status 번호만 피하는 방식으로 작성했는데,
이는 클라이언트 입장에서 헷갈릴 수도 있고, 새로 Status가 생기는 경우가 있을 수 있다고 생각했다.

이제 모든 응답을 ResponseEntity로 응답하도록 바꾸어 주고, Controller Advice를 이용해 예외 처리를 해주면 될 것 같다.