### PR TITLE
읽기 작업에 대해 @Transactional read only 옵션 적용 #32

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
@@ -118,6 +118,7 @@ public class AttendanceService {
         return new AttendanceDto(lecture, new ArrayList<>());
     }
 
+    @Transactional(readOnly = true)
     public AttendanceDto getDayAttendances(Long lectureId, Long milliseconds) {
         LocalDateTime timestamp = getLocalDateTime(milliseconds).withHour(0).withMinute(0).withSecond(0);
         List<Attendance> attendances = attendanceRepository.findByLectureIdAndTimestampBetween(lectureId, timestamp, timestamp.plusDays(1));

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
@@ -22,11 +22,11 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service
@@ -91,6 +91,7 @@ public class AttendanceService {
             .ofInstant(Instant.ofEpochMilli(milliseconds), ZoneId.of("Asia/Seoul"));
     }
 
+    @Transactional(readOnly = true)
     public AttendanceDto getAttendances(Long lectureId) {
         List<Attendance> attendances = attendanceRepository.findAllByLectureId(lectureId);
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public SignInRequestValidationResult validateSignInRequest(SignInRequest signInRequest) {
         Member member = memberRepository.findByUnivId(signInRequest.getUnivId())
             .orElseThrow(() -> MemberNotFoundException.EXCEPTION);

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -10,11 +10,11 @@ import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.core.member.MemberRepository;
 import gdsc.binaryho.imhere.core.member.Role;
 import gdsc.binaryho.imhere.core.member.application.request.RoleChangeRequest;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/PrincipalDetailsService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/PrincipalDetailsService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PrincipalDetailsService implements UserDetailsService {
@@ -18,6 +19,7 @@ public class PrincipalDetailsService implements UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String univId) {
         Member member = memberRepository.findByUnivId(univId)
             .orElseThrow(() -> {

--- a/src/main/java/gdsc/binaryho/imhere/core/enrollment/application/EnrollmentService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/enrollment/application/EnrollmentService.java
@@ -15,10 +15,10 @@ import gdsc.binaryho.imhere.core.member.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Log4j2

--- a/src/main/java/gdsc/binaryho/imhere/core/enrollment/application/EnrollmentService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/enrollment/application/EnrollmentService.java
@@ -107,6 +107,7 @@ public class EnrollmentService {
             , () -> enrollmentInfo.getMember().getUnivId(), () -> enrollmentInfo.getMember().getName());
     }
 
+    @Transactional(readOnly = true)
     public EnrollmentInfoDto getLectureEnrollment(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
             .orElseThrow(() -> LectureNotFoundException.EXCEPTION);

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -41,6 +41,7 @@ public class LectureService {
         lectureRepository.save(newLecture);
     }
 
+    @Transactional(readOnly = true)
     public List<Lecture> getStudentLectures() {
         Member currentStudent = authenticationHelper.getCurrentMember();
         List<EnrollmentInfo> enrollmentInfos = enrollmentInfoRepository
@@ -50,6 +51,7 @@ public class LectureService {
         return getLectures(enrollmentInfos);
     }
 
+    @Transactional(readOnly = true)
     public List<Lecture> getStudentOpenLectures() {
         Member currentStudent = authenticationHelper.getCurrentMember();
         List<EnrollmentInfo> enrollmentInfos = enrollmentInfoRepository
@@ -65,6 +67,7 @@ public class LectureService {
             .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public List<LectureDto> getOwnedLectures() {
         Member currentLecturer = authenticationHelper.getCurrentMember();
         List<Lecture> lectures = lectureRepository.findAllByMemberId(currentLecturer.getId());

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
@@ -15,7 +15,6 @@ import gdsc.binaryho.imhere.core.member.MemberRepository;
 import gdsc.binaryho.imhere.core.member.Role;
 import gdsc.binaryho.imhere.core.member.application.request.RoleChangeRequest;
 import java.security.InvalidParameterException;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class AuthServiceTest {


### PR DESCRIPTION
# 읽기 작업에 대해 @Transactional read only 옵션 적용 #32 

적용 이유
1. 엔티티의 등록, 변경, 삭제를 강제로 방지할 수 있다.
2. readOnly true 옵션은 세션 플러시 모드가 MANUAL이 된다. 따로 플러시가 되지 않아서, 변화 방지가 가능하다.
3. 그리고 영속성 컨텍스트가 더티 채킹을 위한 스냅샷을 운용하지 않으므로 성능이 향상됨.

작업
1. Transaction의 다양한 옵션 사용을 위해 javax Transactional를 사용하는 부분을 springframework Transactional 사용으로 변경
2. read 메서드에 대해 @transactional read only 선언