### PR TITLE
[refactor] Request DTO에 AllArgsConstructor 제공 #38

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/model/request/AttendanceRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/model/request/AttendanceRequest.java
@@ -2,11 +2,13 @@ package gdsc.binaryho.imhere.core.attendance.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class AttendanceRequest {
 
     @Schema(description = "출석 번호")

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignInRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignInRequest.java
@@ -2,11 +2,13 @@ package gdsc.binaryho.imhere.core.auth.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SignInRequest {
 
     @Schema(description = "회원가입 email에서 @와 도메인을 포함한 부분을 제외한 앞 부분")

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignInRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignInRequest.java
@@ -1,13 +1,10 @@
 package gdsc.binaryho.imhere.core.auth.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class SignInRequest {
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignUpRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SignUpRequest.java
@@ -2,11 +2,13 @@ package gdsc.binaryho.imhere.core.auth.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SignUpRequest {
 
     @Schema(description = "회원가입 email에서 @와 도메인을 포함한 부분을 제외한 앞 부분")

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/response/SignInRequestValidationResult.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/response/SignInRequestValidationResult.java
@@ -1,15 +1,13 @@
 package gdsc.binaryho.imhere.core.auth.model.response;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @Tag(name = "SignInRequestValidationResult", description = "로그인한 유저 id와 비밀번호를 검증한 다음 유저의 권한을 반환한다")
+@AllArgsConstructor
 public class SignInRequestValidationResult {
 
     private final String roleKey;
-
-    public SignInRequestValidationResult(String roleKey) {
-        this.roleKey = roleKey;
-    }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/enrollment/model/request/EnrollmentRequestForLecturer.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/enrollment/model/request/EnrollmentRequestForLecturer.java
@@ -3,11 +3,13 @@ package gdsc.binaryho.imhere.core.enrollment.model.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class EnrollmentRequestForLecturer {
 
     @Schema(description = "학생 id 리스트")

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/model/request/LectureCreateRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/model/request/LectureCreateRequest.java
@@ -2,11 +2,13 @@ package gdsc.binaryho.imhere.core.lecture.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class LectureCreateRequest {
 
     @Schema(description = "생성할 강좌 이름")

--- a/src/main/java/gdsc/binaryho/imhere/core/member/model/request/RoleChangeRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/member/model/request/RoleChangeRequest.java
@@ -2,11 +2,13 @@ package gdsc.binaryho.imhere.core.member.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class RoleChangeRequest {
 
     @Schema(description = "role을 string으로 표현합니다.", example = "ex) ROLE_STUDENT / ROLE_LECTURER / ROLE_ADMIN 과 같은 String")


### PR DESCRIPTION
## What is this Pull Request about? 💬
기존 나의 Request DTO는

1. private field
2. No Arguments Constructor + AccessLevel Protected
3. Getter
이렇게 3가지 특징을 가진 Request 를 사용하는 것을 시도했다 -> https://github.com/binary-ho/imhere-server/issues/36 Reqeust Response 리팩토링


이렇게 3가지만 있어도, RestController의 ResponseBody annotation을 통해 Request의 생성이 가능했기 때문이다.
가능한 이유는 Response Body는 Message Converter가 No Arguments 생성자를 통해 객체를 생성한 다음 리플렉션을 통해 Getter 메서드의 이름만으로 필드명을 파악해서 값을 주입할 수 있어서 위 구성만으로도 Request 객체를 만들 수 있었다.

Access Level은 Request가 쓰인 객체 안에서만 쓰이기 위해 사용했다.

문제는 이런 구성으로 Request를 이용하면, 테스트 과정에서 Request를 만들기가 너무 어렵다.
더 나은 테스트를 위해 Request의 생성을 AllArgConstructor을 제공해 생성하는 방식으로 변경하겠다.
모든 변수를 final로 만들고 싶어 기본 생성자 어노테이션을 제거하고, Builder를 추가하는 방식도 고려했었다.
아니면 JsonProperty와 관련된 여러 어노테이션들을 활용하는 방식도 고려했었으나,
DTO를 final로 만들 필요도 딱히 없다고 느껴졌고, 개인적으로는 Builder를 잘 사용하지 않아서 AllArgConstructor를 선택

<br>

## Key Changes 🔑

- DTO에 all arguments constructor 제공
- SingnInRequest에서 필요 없는 NoArgsConstructor 제거

