### PR TITLE
[refactor] EmailSender에서 발생하는 에러를 Custom Exception으로 Wrapping #40

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -6,13 +6,9 @@ import gdsc.binaryho.imhere.core.auth.util.EmailSender;
 import gdsc.binaryho.imhere.exception.ImhereException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.UnsupportedEncodingException;
-import javax.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mail.MailException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,15 +48,8 @@ public class AuthController {
     @Operation(summary = "특정 이메일로 회원가입 코드를 발급하여 발송하는 API")
     @PostMapping("/verification/{email}")
     public ResponseEntity<Void> generateVerificationNumber(@PathVariable("email") String email) {
-        try {
-            emailSender.sendMailAndGetVerificationCode(email);
-            return ResponseEntity.ok().build();
-        } catch (MailException | MessagingException | UnsupportedEncodingException error) {
-            log.info("[이메일 인증 번호 전송 에러] email : {}", email);
-            return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .build();
-        }
+        emailSender.sendMailAndGetVerificationCode(email);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "특정 이메일에 발급된 회원가입 코드와 입력된 코드의 일치여부를 확인하는 API")

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/exception/MessagingServerException.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/exception/MessagingServerException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.core.auth.exception;
+
+import gdsc.binaryho.imhere.exception.ErrorInfo;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class MessagingServerException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new MessagingServerException();
+
+    private MessagingServerException() {
+        super(ErrorInfo.MESSAGING_SERVER_EXCEPTION);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailSender.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailSender.java
@@ -24,6 +24,7 @@ public class EmailSender {
 
     private static final String SENDER_PERSONAL = "jinholee";
     private static final String SENDER_ADDRESS = "gdscimhere@gmail.com";
+    private static final String MESSAGE_SUBJECT = "Hello There! GDSC Hongik i'm here 회원가입 인증 코드입니다.";
     private final static String MESSAGE_PREFIX = ""
         + "<div style='margin:20px;'>"
         + "<div style='margin:20px;'>"
@@ -64,7 +65,7 @@ public class EmailSender {
         MimeMessage message = emailSender.createMimeMessage();
 
         message.addRecipients(RecipientType.TO, recipient);
-        message.setSubject("Hello There! GDSC Hongik i'm here 회원가입 인증 코드입니다.");
+        message.setSubject(MESSAGE_SUBJECT);
         message.setText(getMessage(verificationCode), "utf-8", "html");
         message.setFrom(getInternetAddress());
         return message;

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailSender.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailSender.java
@@ -2,6 +2,7 @@ package gdsc.binaryho.imhere.core.auth.util;
 
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
+import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
 import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 import java.util.UUID;
@@ -21,6 +22,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailSender {
 
+    private static final String SENDER_PERSONAL = "jinholee";
+    private static final String SENDER_ADDRESS = "gdscimhere@gmail.com";
     private final static String MESSAGE_PREFIX = ""
         + "<div style='margin:20px;'>"
         + "<div style='margin:20px;'>"
@@ -39,28 +42,31 @@ public class EmailSender {
     private final StringBuilder stringBuilder = new StringBuilder();
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void sendMailAndGetVerificationCode(String recipient)
-        throws MessagingException, UnsupportedEncodingException {
+    public void sendMailAndGetVerificationCode(String recipient) {
         validateEmailForm(recipient);
 
         String verificationCode = UUID.randomUUID().toString();
 
-        MimeMessage message = writeMail(recipient, verificationCode);
-        emailSender.send(message);
+        try {
+            MimeMessage message = writeMessage(recipient, verificationCode);
+            emailSender.send(message);
+        } catch (MessagingException e) {
+            throw MessagingServerException.EXCEPTION;
+        }
+
         setVerificationCode(recipient, verificationCode);
 
         log.info("[인증 이메일 발송] " + recipient + ", 인증 번호 : " + verificationCode);
     }
 
-    private MimeMessage writeMail(String recipient, String verificationCode)
-        throws MessagingException, UnsupportedEncodingException {
+    private MimeMessage writeMessage(String recipient, String verificationCode)
+        throws MessagingException {
         MimeMessage message = emailSender.createMimeMessage();
 
         message.addRecipients(RecipientType.TO, recipient);
         message.setSubject("Hello There! GDSC Hongik i'm here 회원가입 인증 코드입니다.");
-
         message.setText(getMessage(verificationCode), "utf-8", "html");
-        message.setFrom(new InternetAddress("gdscimhere@gmail.com", "jinholee"));
+        message.setFrom(getInternetAddress());
         return message;
     }
 
@@ -69,6 +75,16 @@ public class EmailSender {
         return String.valueOf(stringBuilder.append(MESSAGE_PREFIX)
             .append(verificationCode)
             .append(MESSAGE_SUFFIX));
+    }
+
+    private InternetAddress getInternetAddress() {
+        try {
+            return new InternetAddress(SENDER_ADDRESS, SENDER_PERSONAL);
+        } catch (UnsupportedEncodingException unsupportedEncodingException) {
+            log.error("[UnsupportedEncodingException] address : {}, personal : {}",
+                SENDER_ADDRESS, SENDER_PERSONAL);
+            return new InternetAddress();
+        }
     }
 
     private void setVerificationCode(String recipient, String verificationCode) {

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
@@ -15,6 +15,7 @@ public enum ErrorInfo {
     PASSWORD_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1005, "형식에 맞는 비밀번호를 입력하세요."),
     REQUEST_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1006, "요청 형식이 맞지 않습니다."),
     EMAIL_VERIFICATION_CODE_INCORRECT(HttpStatus.BAD_REQUEST, 1007, "Email 인증 번호가 불일치합니다."),
+    MESSAGING_SERVER_EXCEPTION(HttpStatus.NOT_FOUND, 1008, "Messaging Server 에 연결할 수 없습니다."),
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "강의 정보가 없습니다."),
     LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 2002, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),


### PR DESCRIPTION
## What is this Pull Request about? 💬
MailSender에서 발생하는 예외 MessagingException, UnsupportedEncodingException 가 발생했을 경우,
실패 응답을 주고, advice를 통해 예외를 핸들링하면서 controller에서는 try-catch를 제거하기 위해 MessagingException, UnsupportedEncodingException를 Custom 예외로 Wrapping할 필요를 느꼈다.

<br>

## Key Changes 🔑

- Mail Sender에서 발생하는 Exception을 Custom Exception으로 Wrapping하기
- Mail Sender에서 예외가 발생하면 커스텀 예외를 발생시키기
- Controller 에서 Exception Catch 제거

<br>
