### PR TITLE
RedisTemplate 사용 로직을 각 역할에 맞게 Repository로 추상화 #45

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
@@ -78,20 +78,20 @@ public class AttendanceService {
 
     private void validateAttendanceNumber(EnrollmentInfo enrollmentInfo, int attendanceNumber) {
         long lectureId = enrollmentInfo.getLecture().getId();
-        String actualAttendanceNumber = attendanceNumberRepository.getByLectureId(lectureId);
+        Integer actualAttendanceNumber = attendanceNumberRepository.getByLectureId(lectureId);
 
         validateAttendanceNumberNotTimeOut(actualAttendanceNumber);
         validateAttendanceNumberCorrect(actualAttendanceNumber, attendanceNumber);
     }
 
-    private void validateAttendanceNumberNotTimeOut(String attendanceNumber) {
+    private void validateAttendanceNumberNotTimeOut(Integer attendanceNumber) {
         if (Objects.isNull(attendanceNumber)) {
             throw AttendanceTimeExceededException.EXCEPTION;
         }
     }
 
-    private void validateAttendanceNumberCorrect(String actualAttendanceNumber, int attendanceNumber) {
-        if (Integer.parseInt(actualAttendanceNumber) != attendanceNumber) {
+    private void validateAttendanceNumberCorrect(Integer actualAttendanceNumber, int attendanceNumber) {
+        if (actualAttendanceNumber != attendanceNumber) {
             throw AttendanceNumberIncorrectException.EXCEPTION;
         }
     }
@@ -144,6 +144,6 @@ public class AttendanceService {
 
     @Transactional
     public void saveAttendanceNumber(Long lectureId, int attendanceNumber) {
-        attendanceNumberRepository.saveByLectureId(lectureId, attendanceNumber);
+        attendanceNumberRepository.saveWithLectureIdAsKey(lectureId, attendanceNumber);
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/port/AttendanceNumberRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/port/AttendanceNumberRepository.java
@@ -1,0 +1,8 @@
+package gdsc.binaryho.imhere.core.attendance.application.port;
+
+public interface AttendanceNumberRepository {
+
+    String getByLectureId(Long lectureId);
+
+    void saveByLectureId(Long lectureId, int attendanceNumber);
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/port/AttendanceNumberRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/port/AttendanceNumberRepository.java
@@ -2,7 +2,7 @@ package gdsc.binaryho.imhere.core.attendance.application.port;
 
 public interface AttendanceNumberRepository {
 
-    String getByLectureId(Long lectureId);
+    Integer getByLectureId(Long lectureId);
 
-    void saveByLectureId(Long lectureId, int attendanceNumber);
+    void saveWithLectureIdAsKey(Long lectureId, int attendanceNumber);
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
@@ -14,13 +14,19 @@ public class AttendanceNumberRedisRepository implements AttendanceNumberReposito
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
-    public String getByLectureId(Long lectureId) {
-        return redisTemplate.opsForValue()
+    public Integer getByLectureId(Long lectureId) {
+        String attendanceNumber = redisTemplate.opsForValue()
             .get(lectureId.toString());
+
+        if (attendanceNumber == null) {
+            return null;
+        }
+
+        return Integer.parseInt(attendanceNumber);
     }
 
     @Override
-    public void saveByLectureId(Long lectureId, int attendanceNumber) {
+    public void saveWithLectureIdAsKey(Long lectureId, int attendanceNumber) {
         redisTemplate.opsForValue().set(
             lectureId.toString(),
             String.valueOf(attendanceNumber),

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
@@ -1,0 +1,31 @@
+package gdsc.binaryho.imhere.core.attendance.infrastructure;
+
+import gdsc.binaryho.imhere.core.attendance.application.port.AttendanceNumberRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AttendanceNumberRedisRepository implements AttendanceNumberRepository {
+
+    private final static Integer ATTENDANCE_NUMBER_EXPIRE_TIME = 10;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public String getByLectureId(Long lectureId) {
+        return redisTemplate.opsForValue()
+            .get(lectureId.toString());
+    }
+
+    @Override
+    public void saveByLectureId(Long lectureId, int attendanceNumber) {
+        redisTemplate.opsForValue().set(
+            lectureId.toString(),
+            String.valueOf(attendanceNumber),
+            ATTENDANCE_NUMBER_EXPIRE_TIME,
+            TimeUnit.MINUTES
+        );
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/port/VerificationCodeRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/port/VerificationCodeRepository.java
@@ -1,0 +1,8 @@
+package gdsc.binaryho.imhere.core.auth.application.port;
+
+public interface VerificationCodeRepository {
+
+    String getByEmail(String email);
+
+    void saveWithEmailAsKey(String email, String verificationCode);
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package gdsc.binaryho.imhere.core.auth.controller;
 
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
+import gdsc.binaryho.imhere.core.auth.application.EmailSender;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
-import gdsc.binaryho.imhere.core.auth.util.EmailSender;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/VerificationCodeRedisRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/VerificationCodeRedisRepository.java
@@ -1,0 +1,34 @@
+package gdsc.binaryho.imhere.core.auth.infrastructure;
+
+import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationCodeRedisRepository implements VerificationCodeRepository {
+
+    private final static Integer VERIFICATION_CODE_EXPIRE_TIME = 10;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public String getByEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+
+        return redisTemplate.opsForValue().get(email);
+    }
+
+    @Override
+    public void saveWithEmailAsKey(String email, String verificationCode) {
+        redisTemplate.opsForValue().set(
+            email,
+            verificationCode,
+            VERIFICATION_CODE_EXPIRE_TIME,
+            TimeUnit.MINUTES
+        );
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.core.lecture.application;
 
+import gdsc.binaryho.imhere.core.attendance.application.AttendanceService;
 import gdsc.binaryho.imhere.core.auth.util.AuthenticationHelper;
 import gdsc.binaryho.imhere.core.enrollment.EnrollmentInfo;
 import gdsc.binaryho.imhere.core.enrollment.EnrollmentState;
@@ -13,11 +14,9 @@ import gdsc.binaryho.imhere.core.lecture.model.response.LectureResponse;
 import gdsc.binaryho.imhere.core.member.Member;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,12 +27,11 @@ public class LectureService {
 
     private final static Integer RANDOM_NUMBER_START = 100;
     private final static Integer RANDOM_NUMBER_END = 1000;
-    private final static Integer ATTENDANCE_NUMBER_EXPIRE_TIME = 10;
 
     private final AuthenticationHelper authenticationHelper;
+    private final AttendanceService attendanceService;
     private final LectureRepository lectureRepository;
     private final EnrollmentInfoRepository enrollmentInfoRepository;
-    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
     public void createLecture(LectureCreateRequest request) {
@@ -98,14 +96,8 @@ public class LectureService {
 
         lecture.setLectureState(LectureState.OPEN);
 
-        Integer attendanceNumber = generateRandomNumber();
-
-        redisTemplate.opsForValue().set(
-            String.valueOf(lecture.getId()),
-            String.valueOf(attendanceNumber),
-            ATTENDANCE_NUMBER_EXPIRE_TIME,
-            TimeUnit.MINUTES
-        );
+        int attendanceNumber = generateRandomNumber();
+        attendanceService.saveAttendanceNumber(lecture.getId(), attendanceNumber);
 
         log.info("[강의 OPEN] {} ({}), 출석 번호 : " + attendanceNumber
             , () -> lecture.getLectureName(), () -> lecture.getId());

--- a/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
@@ -1,0 +1,133 @@
+package gdsc.binaryho.imhere.core.attendance;
+
+import static gdsc.binaryho.imhere.fixture.MemberFixture.LECTURER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import gdsc.binaryho.imhere.MockMember;
+import gdsc.binaryho.imhere.core.attendance.application.AttendanceService;
+import gdsc.binaryho.imhere.core.attendance.application.port.AttendanceNumberRepository;
+import gdsc.binaryho.imhere.core.attendance.exception.AttendanceNumberIncorrectException;
+import gdsc.binaryho.imhere.core.attendance.exception.AttendanceTimeExceededException;
+import gdsc.binaryho.imhere.core.attendance.infrastructure.AttendanceRepository;
+import gdsc.binaryho.imhere.core.attendance.model.request.AttendanceRequest;
+import gdsc.binaryho.imhere.core.auth.util.AuthenticationHelper;
+import gdsc.binaryho.imhere.core.enrollment.EnrollmentInfo;
+import gdsc.binaryho.imhere.core.enrollment.EnrollmentState;
+import gdsc.binaryho.imhere.core.enrollment.infrastructure.EnrollmentInfoRepository;
+import gdsc.binaryho.imhere.core.lecture.Lecture;
+import gdsc.binaryho.imhere.core.lecture.LectureState;
+import gdsc.binaryho.imhere.core.lecture.infrastructure.LectureRepository;
+import gdsc.binaryho.imhere.fixture.AttendanceFixture;
+import gdsc.binaryho.imhere.fixture.MemberFixture;
+import gdsc.binaryho.imhere.mock.FakeAttendanceNumberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class AttendanceServiceTest {
+
+    private final int ATTENDANCE_NUMBER = AttendanceFixture.ATTENDANCE_NUMBER;
+    private final String DISTANCE = AttendanceFixture.DISTANCE;
+    private final String ACCURACY = AttendanceFixture.ACCURACY;
+    private final long MILLISECONDS = AttendanceFixture.MILLISECONDS;
+
+    private final Lecture OPEN_LECTURE = getMockOpenLecture();
+    private final EnrollmentInfo ENROLLMENT_INFO = EnrollmentInfo
+        .createEnrollmentInfo(OPEN_LECTURE, MemberFixture.STUDENT, EnrollmentState.APPROVAL);
+
+    @Autowired
+    AuthenticationHelper authenticationHelper;
+    @Mock
+    AttendanceRepository attendanceRepository;
+    @Mock
+    EnrollmentInfoRepository enrollmentRepository;
+    @Autowired
+    LectureRepository lectureRepository;
+
+    AttendanceNumberRepository attendanceNumberRepository = new FakeAttendanceNumberRepository();
+    AttendanceService attendanceService;
+
+    @BeforeEach
+    void saveAllEntities() {
+        attendanceService = new AttendanceService(
+            authenticationHelper, attendanceRepository, enrollmentRepository, lectureRepository, attendanceNumberRepository);
+
+        // EnrollmentRepository Mocking
+        given(enrollmentRepository
+            .findByMemberIdAndLectureIdAndEnrollmentState(any(), eq(OPEN_LECTURE.getId()), eq(EnrollmentState.APPROVAL)))
+            .willReturn(Optional.of(ENROLLMENT_INFO));
+    }
+
+    @Test
+    @MockMember
+    void 저장된_출석_번호와_학생이_제출한_출석번호가_일치하는_경우_학생은_출석된다() {
+        // given
+        // when
+        AttendanceRequest request = new AttendanceRequest(ATTENDANCE_NUMBER, DISTANCE, ACCURACY, MILLISECONDS);
+        attendanceNumberRepository.saveWithLectureIdAsKey(OPEN_LECTURE.getId(), ATTENDANCE_NUMBER);
+        attendanceService.takeAttendance(request, OPEN_LECTURE.getId());
+
+        // then
+        verify(attendanceRepository, times(1)).save(any());
+    }
+
+    @Test
+    @MockMember
+    void 수업에_저장된_출석_번호가_없는_경우_예외를_발생시킨다() {
+        // given
+        // when
+        AttendanceRequest request = new AttendanceRequest(ATTENDANCE_NUMBER, DISTANCE, ACCURACY, MILLISECONDS);
+        Integer attendanceNumber = attendanceNumberRepository.getByLectureId(OPEN_LECTURE.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(attendanceNumber).isEqualTo(null),
+            () -> assertThatThrownBy(
+                () -> attendanceService.takeAttendance(request, OPEN_LECTURE.getId()))
+                .isInstanceOf(AttendanceTimeExceededException.class)
+        );
+    }
+
+    @Test
+    @MockMember
+    void 저장된_출석_번호와_학생이_제출한_출석번호가_다른_경우_예외를_발생시킨다() {
+        // given
+        // when
+        AttendanceRequest request = new AttendanceRequest(ATTENDANCE_NUMBER, DISTANCE, ACCURACY, MILLISECONDS);
+        int wrongNumber = ATTENDANCE_NUMBER + 7;
+        attendanceNumberRepository.saveWithLectureIdAsKey(OPEN_LECTURE.getId(), wrongNumber);
+
+        // then
+        assertThatThrownBy(
+            () -> attendanceService.takeAttendance(request, OPEN_LECTURE.getId()))
+            .isInstanceOf(AttendanceNumberIncorrectException.class);
+    }
+
+    /*@Transactional
+    public void saveAttendanceNumber(Long lectureId, int attendanceNumber) {
+        attendanceNumberRepository.saveByLectureId(lectureId, attendanceNumber);
+    }*/
+
+    @Test
+    void 출석_번호를_강의_아이디와_함께_저장할_수_있다() {
+
+    }
+
+    private Lecture getMockOpenLecture() {
+        Lecture lecture = Lecture.createLecture(LECTURER, "mockLecture");
+        lecture.setId(1L);
+        lecture.setLectureState(LectureState.OPEN);
+        return lecture;
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
@@ -59,7 +59,7 @@ public class AttendanceServiceTest {
     AttendanceService attendanceService;
 
     @BeforeEach
-    void saveAllEntities() {
+    void beforeEachTest() {
         attendanceService = new AttendanceService(
             authenticationHelper, attendanceRepository, enrollmentRepository, lectureRepository, attendanceNumberRepository);
 

--- a/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/attendance/AttendanceServiceTest.java
@@ -114,14 +114,14 @@ public class AttendanceServiceTest {
             .isInstanceOf(AttendanceNumberIncorrectException.class);
     }
 
-    /*@Transactional
-    public void saveAttendanceNumber(Long lectureId, int attendanceNumber) {
-        attendanceNumberRepository.saveByLectureId(lectureId, attendanceNumber);
-    }*/
-
     @Test
     void 출석_번호를_강의_아이디와_함께_저장할_수_있다() {
+        // given
+        // when
+        attendanceService.saveAttendanceNumber(LECTURER.getId(), ATTENDANCE_NUMBER);
 
+        // then
+        assertThat(attendanceNumberRepository.getByLectureId(LECTURER.getId())).isEqualTo(ATTENDANCE_NUMBER);
     }
 
     private Lecture getMockOpenLecture() {

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/EmailSenderTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/EmailSenderTest.java
@@ -1,0 +1,130 @@
+package gdsc.binaryho.imhere.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import gdsc.binaryho.imhere.core.auth.application.EmailSender;
+import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
+import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
+import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
+import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
+import gdsc.binaryho.imhere.mock.FakeVerificationCodeRepository;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailSenderTest {
+
+    @Mock
+    JavaMailSender javaMailSender;
+
+    @Mock
+    MimeMessage mockMimeMessage;
+
+    VerificationCodeRepository verificationCodeRepository = new FakeVerificationCodeRepository();
+    EmailSender emailSender;
+
+    @BeforeEach
+    void initEmailSender() {
+        emailSender = new EmailSender(javaMailSender, verificationCodeRepository);
+    }
+
+    private static final String EMAIL = "dlwlsgh4687@gmail.com";
+
+    @Test
+    void 회원가임_시도_이메일에_메일을_보낼_수_있다() {
+        // given
+        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+        // then
+        emailSender.sendMailAndGetVerificationCode(EMAIL);
+
+        // then
+        verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"naver.com", "mail.hongik.ac.kr", "g.hongik.ac.k", "gmail.net"})
+    void 홍익대학교_이메일이나_구글_이메일이_아닌_경우_예외_발생(String postfix) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() ->
+            emailSender.sendMailAndGetVerificationCode("test@" + postfix))
+            .isInstanceOf(EmailFormatMismatchException.class);
+    }
+
+    @Test
+    void 메시지_기록중_MessagingException_이_발생하는_경우_커스텀_예외인_MessagingServerException_발생() throws MessagingException {
+        // given
+        // when
+        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+        doThrow(new MessagingException()).when(mockMimeMessage).addRecipients(RecipientType.TO, EMAIL);
+
+        // then
+        assertThatThrownBy(
+            () -> emailSender.sendMailAndGetVerificationCode(EMAIL)
+        ).isInstanceOf(MessagingServerException.class);
+    }
+
+    @Test
+    void 이메일_발송과_함께_인증_코드가_저장된다() {
+        // given
+        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+        // when
+        emailSender.sendMailAndGetVerificationCode(EMAIL);
+
+        // then
+        assertThat(verificationCodeRepository.getByEmail(EMAIL)).isNotNull();
+    }
+
+    @Test
+    void 인증_코드를_인증할_수_있다() {
+        // given
+        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+        // when
+        emailSender.sendMailAndGetVerificationCode(EMAIL);
+        String verificationCode = verificationCodeRepository.getByEmail(EMAIL);
+
+        // then
+        assertThatCode(
+            () -> emailSender.verifyCode(EMAIL, verificationCode)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 인증_코드가_틀린_경우_예외를_발생시킨다() {
+        // given
+        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+        // when
+        emailSender.sendMailAndGetVerificationCode(EMAIL);
+
+        // then
+        assertThatThrownBy(
+            () -> emailSender.verifyCode(EMAIL, "WrongCode")
+        ).isInstanceOf(EmailVerificationCodeIncorrectException.class);
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/fixture/AttendanceFixture.java
+++ b/src/test/java/gdsc/binaryho/imhere/fixture/AttendanceFixture.java
@@ -1,0 +1,18 @@
+package gdsc.binaryho.imhere.fixture;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class AttendanceFixture {
+
+    public static int ATTENDANCE_NUMBER = 777;
+    public static String DISTANCE = "7777";
+    public static String ACCURACY = "7";
+    public static long MILLISECONDS = 831340800000L;
+    public static LocalDateTime LOCAL_DATE_TIME = getLocalDateTime();
+
+    private static LocalDateTime getLocalDateTime() {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(MILLISECONDS), ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/fixture/MemberFixture.java
+++ b/src/test/java/gdsc/binaryho/imhere/fixture/MemberFixture.java
@@ -1,0 +1,18 @@
+package gdsc.binaryho.imhere.fixture;
+
+import gdsc.binaryho.imhere.core.member.Member;
+import gdsc.binaryho.imhere.core.member.Role;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class MemberFixture {
+
+    public static final String UNIV_ID = "UNIV_ID";
+    public static final String NAME = "이진호";
+    public static final String RAW_PASSWORD = "abcd1234";
+    public static final String PASSWORD =
+        new BCryptPasswordEncoder().encode(RAW_PASSWORD);
+    public static final Role ROLE = Role.STUDENT;
+
+    public static final Member STUDENT = Member.createMember(UNIV_ID, NAME, PASSWORD, ROLE);
+    public static final Member LECTURER = Member.createMember(UNIV_ID, NAME, PASSWORD, Role.LECTURER);
+}

--- a/src/test/java/gdsc/binaryho/imhere/mock/FakeAttendanceNumberRepository.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/FakeAttendanceNumberRepository.java
@@ -1,0 +1,20 @@
+package gdsc.binaryho.imhere.mock;
+
+import gdsc.binaryho.imhere.core.attendance.application.port.AttendanceNumberRepository;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeAttendanceNumberRepository implements AttendanceNumberRepository {
+
+    private final Map<Long, Integer> data = new HashMap<>();
+
+    @Override
+    public Integer getByLectureId(Long lectureId) {
+        return data.get(lectureId);
+    }
+
+    @Override
+    public void saveWithLectureIdAsKey(Long lectureId, int attendanceNumber) {
+        data.put(lectureId, attendanceNumber);
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/mock/FakeVerificationCodeRepository.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/FakeVerificationCodeRepository.java
@@ -1,0 +1,20 @@
+package gdsc.binaryho.imhere.mock;
+
+import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeVerificationCodeRepository implements VerificationCodeRepository {
+
+    private final Map<String, String> data = new HashMap<>();
+
+    @Override
+    public String getByEmail(String email) {
+        return data.get(email);
+    }
+
+    @Override
+    public void saveWithEmailAsKey(String email, String verificationCode) {
+        data.put(email, verificationCode);
+    }
+}


### PR DESCRIPTION
## What is this Pull Request about? 💬
이슈 -> #45

현재  RedisTemplate를 여러 서비스에서 직접 사용하고 있다.

이렇게 의존성 역전 없이 직접 사용하는 경우, 
테스트시 직접 Redis 서버를 띄워 테스트 해야 해서 테스트가 너무 어렵고, 테스트 시간이 길어진다.

또한, 이런 구체적인 기술과의 강결합은 설계 단계에서 구체적인 기술에 국한된 설계를 유발하고,
결합도가 높아 기술의 변경에 유연하게 대처하기 어렵다. (변경에 취약하다.)

RedisTemplate를 사용중인 로직을 Repository로 추상화한 다음 
빈으로 관리해 의존성을 주입 받아 의존성을 역전하고, 영향을 받는 부분에 대한 테스트 코드를 작성했다.

<br>

## Key Changes 🔑
- 출석 번호를 저장-조회 하기 위한 AttendanceNumberRepository를 application layer에 추가
- RedisTemplate를 이용해 출석 번호를 저장-조회하는 구현체인 AttendanceNumberRedisRepository를 infrastructure layer에 추가
- AttendanceNumberRepository가 영향을 미치는 부분들에 대한 AttendanceServiceTest 구현

<br>

- 인증 코드를 저장-조회 하기 위한 VerificationCodeRepository를 application layer에 추가
- RedisTemplate를 사용해 인증 코드를 저장-조회하는 구현체인 VerificationCodeRedisRepository를 infrastructure layer에 추가
- VerificationCodeRepository가 영향을 미치는 부분들에 대한 EmailSenderTest구현

<br>
