### PR TITLE
JavaMailSender를 사용하는 클래스 추상화 #45

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/config/JavaMailSenderConfig.java
+++ b/src/main/java/gdsc/binaryho/imhere/config/JavaMailSenderConfig.java
@@ -8,7 +8,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 @Configuration
-public class EmailConfig {
+public class JavaMailSenderConfig {
 
     @Value("${mail.smtp.port}")
     private int port;

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -2,7 +2,6 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
-import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
@@ -11,7 +10,6 @@ import gdsc.binaryho.imhere.core.auth.model.response.SignInRequestValidationResu
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.core.member.Role;
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -66,13 +64,6 @@ public class AuthService {
     private void validateMatchesPassword(String rawPassword, String encodedPassword) {
         if (!bCryptPasswordEncoder.matches(rawPassword, encodedPassword)) {
             throw PasswordIncorrectException.EXCEPTION;
-        }
-    }
-
-    public void verifyCode(String email, String verificationCode) {
-        String emailVerificationCode = verificationCodeRepository.getByEmail(email);
-        if (!Objects.equals(emailVerificationCode, verificationCode)) {
-            throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -1,6 +1,8 @@
 package gdsc.binaryho.imhere.core.auth.application;
 
+import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
+import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
@@ -9,6 +11,7 @@ import gdsc.binaryho.imhere.core.auth.model.response.SignInRequestValidationResu
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.core.member.Role;
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final VerificationCodeRepository verificationCodeRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     private static final String PASSWORD_REGEX = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{8,20}$";
@@ -62,6 +66,13 @@ public class AuthService {
     private void validateMatchesPassword(String rawPassword, String encodedPassword) {
         if (!bCryptPasswordEncoder.matches(rawPassword, encodedPassword)) {
             throw PasswordIncorrectException.EXCEPTION;
+        }
+    }
+
+    public void verifyCode(String email, String verificationCode) {
+        String emailVerificationCode = verificationCodeRepository.getByEmail(email);
+        if (!Objects.equals(emailVerificationCode, verificationCode)) {
+            throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailSender.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailSender.java
@@ -2,10 +2,8 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
-import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
 import java.io.UnsupportedEncodingException;
-import java.util.Objects;
 import java.util.UUID;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
@@ -93,13 +91,6 @@ public class EmailSender {
     private void validateEmailForm(String recipient) {
         if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
             throw EmailFormatMismatchException.EXCEPTION;
-        }
-    }
-
-    public void verifyCode(String email, String verificationCode) {
-        String emailVerificationCode = verificationCodeRepository.getByEmail(email);
-        if (!Objects.equals(emailVerificationCode, verificationCode)) {
-            throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -2,8 +2,10 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
+import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
 import java.io.UnsupportedEncodingException;
+import java.util.Objects;
 import java.util.UUID;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
@@ -17,7 +19,7 @@ import org.springframework.stereotype.Service;
 @Log4j2
 @Service
 @RequiredArgsConstructor
-public class EmailSender {
+public class EmailVerificationService {
 
     private static final String SENDER_PERSONAL = "jinholee";
     private static final String SENDER_ADDRESS = "gdscimhere@gmail.com";
@@ -91,6 +93,13 @@ public class EmailSender {
     private void validateEmailForm(String recipient) {
         if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
             throw EmailFormatMismatchException.EXCEPTION;
+        }
+    }
+
+    public void verifyCode(String email, String verificationCode) {
+        String emailVerificationCode = verificationCodeRepository.getByEmail(email);
+        if (!Objects.equals(emailVerificationCode, verificationCode)) {
+            throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -1,19 +1,13 @@
 package gdsc.binaryho.imhere.core.auth.application;
 
+import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
-import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
-import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 import java.util.UUID;
-import javax.mail.Message.RecipientType;
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -21,24 +15,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
-    private static final String SENDER_PERSONAL = "jinholee";
-    private static final String SENDER_ADDRESS = "gdscimhere@gmail.com";
-    private static final String MESSAGE_SUBJECT = "Hello There! GDSC Hongik i'm here 회원가입 인증 코드입니다.";
-    private final static String MESSAGE_PREFIX = ""
-        + "<div style='margin:20px;'>"
-        + "<div style='margin:20px;'>"
-        + "<h1> GDSC Hongik i'm here 인증 코드 입니다! </h1> <br>"
-        + "CODE : <strong>";
-
-    private final static String MESSAGE_SUFFIX = ""
-        + "</strong>"
-        + "<h3> 10분안에 입력 부탁드립니다. 감사합니다! <h3>"
-        + "<br>";
     private final static String EMAIL_REGEX = "^[a-zA-Z0-9]+@(?:(?:g\\.)?hongik\\.ac\\.kr)$";;
     private final static String GMAIL_REGEX = "^[a-zA-Z0-9]+@gmail\\.com$";
-    private final StringBuilder stringBuilder = new StringBuilder();
 
-    private final JavaMailSender emailSender;
+    private final MailSender mailSender;
     private final VerificationCodeRepository verificationCodeRepository;
 
     public void sendMailAndGetVerificationCode(String recipient) {
@@ -46,54 +26,20 @@ public class EmailVerificationService {
 
         String verificationCode = UUID.randomUUID().toString();
 
-        try {
-            MimeMessage message = writeMessage(recipient, verificationCode);
-            emailSender.send(message);
-        } catch (MessagingException e) {
-            throw MessagingServerException.EXCEPTION;
-        }
-
-        setVerificationCode(recipient, verificationCode);
+        mailSender.sendEmailWithVerificationCode(recipient, verificationCode);
+        saveVerificationCodeWithRecipientAsKey(recipient, verificationCode);
 
         log.info("[인증 이메일 발송] " + recipient + ", 인증 번호 : " + verificationCode);
-    }
-
-    private MimeMessage writeMessage(String recipient, String verificationCode)
-        throws MessagingException {
-        MimeMessage message = emailSender.createMimeMessage();
-
-        message.addRecipients(RecipientType.TO, recipient);
-        message.setSubject(MESSAGE_SUBJECT);
-        message.setText(getMessage(verificationCode), "utf-8", "html");
-        message.setFrom(getInternetAddress());
-        return message;
-    }
-
-    private String getMessage(String verificationCode) {
-        stringBuilder.setLength(0);
-        return String.valueOf(stringBuilder.append(MESSAGE_PREFIX)
-            .append(verificationCode)
-            .append(MESSAGE_SUFFIX));
-    }
-
-    private InternetAddress getInternetAddress() {
-        try {
-            return new InternetAddress(SENDER_ADDRESS, SENDER_PERSONAL);
-        } catch (UnsupportedEncodingException unsupportedEncodingException) {
-            log.error("[UnsupportedEncodingException] address : {}, personal : {}",
-                SENDER_ADDRESS, SENDER_PERSONAL);
-            return new InternetAddress();
-        }
-    }
-
-    private void setVerificationCode(String recipient, String verificationCode) {
-        verificationCodeRepository.saveWithEmailAsKey(recipient, verificationCode);
     }
 
     private void validateEmailForm(String recipient) {
         if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
             throw EmailFormatMismatchException.EXCEPTION;
         }
+    }
+
+    private void saveVerificationCodeWithRecipientAsKey(String recipient, String verificationCode) {
+        verificationCodeRepository.saveWithEmailAsKey(recipient, verificationCode);
     }
 
     public void verifyCode(String email, String verificationCode) {

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/port/MailSender.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/port/MailSender.java
@@ -1,0 +1,6 @@
+package gdsc.binaryho.imhere.core.auth.application.port;
+
+public interface MailSender {
+
+    void sendEmailWithVerificationCode(String recipient, String verificationCode);
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package gdsc.binaryho.imhere.core.auth.controller;
 
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
-import gdsc.binaryho.imhere.core.auth.application.EmailSender;
+import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    private final EmailSender emailSender;
+    private final EmailVerificationService emailVerificationService;
 
     @Operation(summary = "회원가입 API")
     @PostMapping("/new")
@@ -36,7 +36,7 @@ public class AuthController {
     @Operation(summary = "특정 이메일로 회원가입 코드를 발급하여 발송하는 API")
     @PostMapping("/verification/{email}")
     public ResponseEntity<Void> generateVerificationNumber(@PathVariable("email") String email) {
-        emailSender.sendMailAndGetVerificationCode(email);
+        emailVerificationService.sendMailAndGetVerificationCode(email);
         return ResponseEntity.ok().build();
     }
 
@@ -44,7 +44,7 @@ public class AuthController {
     @GetMapping("/verification/{email}/{verification-code}")
     public ResponseEntity<Void> verifyCode(@PathVariable("email") String email,
         @PathVariable("verification-code") String verificationCode) {
-        authService.verifyCode(email, verificationCode);
+        emailVerificationService.verifyCode(email, verificationCode);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
     @GetMapping("/verification/{email}/{verification-code}")
     public ResponseEntity<Void> verifyCode(@PathVariable("email") String email,
         @PathVariable("verification-code") String verificationCode) {
-        emailSender.verifyCode(email, verificationCode);
+        authService.verifyCode(email, verificationCode);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/JavaMailSender.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/JavaMailSender.java
@@ -1,0 +1,66 @@
+package gdsc.binaryho.imhere.core.auth.infrastructure;
+
+import static gdsc.binaryho.imhere.core.auth.util.SignUpEmailContents.MESSAGE_PREFIX;
+import static gdsc.binaryho.imhere.core.auth.util.SignUpEmailContents.MESSAGE_SUBJECT;
+import static gdsc.binaryho.imhere.core.auth.util.SignUpEmailContents.MESSAGE_SUFFIX;
+import static gdsc.binaryho.imhere.core.auth.util.SignUpEmailContents.SENDER_ADDRESS;
+import static gdsc.binaryho.imhere.core.auth.util.SignUpEmailContents.SENDER_PERSONAL;
+
+import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
+import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
+import java.io.UnsupportedEncodingException;
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class JavaMailSender implements MailSender {
+
+    private final org.springframework.mail.javamail.JavaMailSender mailSender;
+    private final StringBuilder stringBuilder = new StringBuilder();
+
+    @Override
+    public void sendEmailWithVerificationCode(String recipient, String verificationCode) {
+        try {
+            MimeMessage message = writeMessage(recipient, verificationCode);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw MessagingServerException.EXCEPTION;
+        }
+    }
+
+    private MimeMessage writeMessage(String recipient, String verificationCode)
+        throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+
+        message.addRecipients(RecipientType.TO, recipient);
+        message.setSubject(MESSAGE_SUBJECT);
+        message.setText(getMessage(verificationCode), "utf-8", "html");
+        message.setFrom(getInternetAddress());
+        return message;
+    }
+
+    private String getMessage(String verificationCode) {
+        stringBuilder.setLength(0);
+        return String.valueOf(stringBuilder.append(MESSAGE_PREFIX)
+            .append(verificationCode)
+            .append(MESSAGE_SUFFIX));
+    }
+
+    private InternetAddress getInternetAddress() {
+        try {
+            return new InternetAddress(SENDER_ADDRESS, SENDER_PERSONAL);
+        } catch (UnsupportedEncodingException unsupportedEncodingException) {
+
+            log.error("[UnsupportedEncodingException] address : {}, personal : {}",
+                SENDER_ADDRESS, SENDER_PERSONAL);
+            return new InternetAddress();
+        }
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/util/SignUpEmailContents.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/util/SignUpEmailContents.java
@@ -1,0 +1,19 @@
+package gdsc.binaryho.imhere.core.auth.util;
+
+public class SignUpEmailContents {
+
+    public static final String SENDER_PERSONAL = "jinholee";
+    public static final String SENDER_ADDRESS = "gdscimhere@gmail.com";
+    public static final String MESSAGE_SUBJECT = "Hello There! GDSC Hongik i'm here 회원가입 인증 코드입니다.";
+    public static final String MESSAGE_PREFIX = ""
+        + "<div style='margin:20px;'>"
+        + "<div style='margin:20px;'>"
+        + "<h1> GDSC Hongik i'm here 인증 코드 입니다! </h1> <br>"
+        + "CODE : <strong>";
+
+    public static final String MESSAGE_SUFFIX = ""
+        + "</strong>"
+        + "<h3> 10분안에 입력 부탁드립니다. 감사합니다! <h3>"
+        + "<br>";
+}
+

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
@@ -1,12 +1,15 @@
 package gdsc.binaryho.imhere.core.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
+import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
+import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
@@ -14,7 +17,9 @@ import gdsc.binaryho.imhere.core.auth.model.request.SignInRequest;
 import gdsc.binaryho.imhere.core.auth.model.response.SignInRequestValidationResult;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
+import gdsc.binaryho.imhere.mock.FakeVerificationCodeRepository;
 import javax.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,16 +31,23 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 class AuthServiceTest {
 
     @Autowired
-    private AuthService authService;
-    @Autowired
     private MemberRepository memberRepository;
     @Autowired
     private BCryptPasswordEncoder bCryptPasswordEncoder;
+    private AuthService authService;
 
-    String UNIV_ID = "UNIV_ID";
-    String NAME = "이진호";
-    String PASSWORD = "abcd1234";
-    String DEFAULT_MEMBER_ROLE = "ROLE_STUDENT";
+    VerificationCodeRepository verificationCodeRepository = new FakeVerificationCodeRepository();
+
+    private static final String UNIV_ID = "UNIV_ID";
+    private static final String NAME = "이진호";
+    private static final String PASSWORD = "abcd1234";
+    private static final String DEFAULT_MEMBER_ROLE = "ROLE_STUDENT";
+    private static final String EMAIL = "dlwlsgh4687@gmail.com";
+
+    @BeforeEach
+    void initAuthService() {
+        authService = new AuthService(memberRepository, verificationCodeRepository, bCryptPasswordEncoder);
+    }
 
     @Test
     @Transactional
@@ -106,5 +118,31 @@ class AuthServiceTest {
             authService.validateSignInRequest(new SignInRequest(UNIV_ID, PASSWORD));
 
         assertThat(signInRequestValidationResult.getRoleKey()).isEqualTo(DEFAULT_MEMBER_ROLE);
+    }
+
+    @Test
+    void 인증_코드를_인증할_수_있다() {
+        // given
+        String verificationCode = "imhere forever";
+        verificationCodeRepository.saveWithEmailAsKey(EMAIL, verificationCode);
+
+        // when
+        // then
+        assertThatCode(
+            () -> authService.verifyCode(EMAIL, verificationCode)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 인증_코드가_틀린_경우_예외를_발생시킨다() {
+        // given
+        String verificationCode = "imhere forever";
+        verificationCodeRepository.saveWithEmailAsKey(EMAIL, verificationCode);
+
+        // when
+        // then
+        assertThatThrownBy(
+            () -> authService.verifyCode(EMAIL, verificationCode + "wrong code")
+        ).isInstanceOf(EmailVerificationCodeIncorrectException.class);
     }
 }

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/AuthServiceTest.java
@@ -1,7 +1,6 @@
 package gdsc.binaryho.imhere.core.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -9,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
-import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
@@ -42,7 +40,6 @@ class AuthServiceTest {
     private static final String NAME = "이진호";
     private static final String PASSWORD = "abcd1234";
     private static final String DEFAULT_MEMBER_ROLE = "ROLE_STUDENT";
-    private static final String EMAIL = "dlwlsgh4687@gmail.com";
 
     @BeforeEach
     void initAuthService() {
@@ -118,31 +115,5 @@ class AuthServiceTest {
             authService.validateSignInRequest(new SignInRequest(UNIV_ID, PASSWORD));
 
         assertThat(signInRequestValidationResult.getRoleKey()).isEqualTo(DEFAULT_MEMBER_ROLE);
-    }
-
-    @Test
-    void 인증_코드를_인증할_수_있다() {
-        // given
-        String verificationCode = "imhere forever";
-        verificationCodeRepository.saveWithEmailAsKey(EMAIL, verificationCode);
-
-        // when
-        // then
-        assertThatCode(
-            () -> authService.verifyCode(EMAIL, verificationCode)
-        ).doesNotThrowAnyException();
-    }
-
-    @Test
-    void 인증_코드가_틀린_경우_예외를_발생시킨다() {
-        // given
-        String verificationCode = "imhere forever";
-        verificationCodeRepository.saveWithEmailAsKey(EMAIL, verificationCode);
-
-        // when
-        // then
-        assertThatThrownBy(
-            () -> authService.verifyCode(EMAIL, verificationCode + "wrong code")
-        ).isInstanceOf(EmailVerificationCodeIncorrectException.class);
     }
 }

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/EmailSenderTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/EmailSenderTest.java
@@ -1,7 +1,6 @@
 package gdsc.binaryho.imhere.core.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -13,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import gdsc.binaryho.imhere.core.auth.application.EmailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
-import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
 import gdsc.binaryho.imhere.mock.FakeVerificationCodeRepository;
 import javax.mail.Message.RecipientType;
@@ -40,12 +38,12 @@ public class EmailSenderTest {
     VerificationCodeRepository verificationCodeRepository = new FakeVerificationCodeRepository();
     EmailSender emailSender;
 
+    private static final String EMAIL = "dlwlsgh4687@gmail.com";
+
     @BeforeEach
     void initEmailSender() {
         emailSender = new EmailSender(javaMailSender, verificationCodeRepository);
     }
-
-    private static final String EMAIL = "dlwlsgh4687@gmail.com";
 
     @Test
     void 회원가임_시도_이메일에_메일을_보낼_수_있다() {
@@ -95,36 +93,5 @@ public class EmailSenderTest {
 
         // then
         assertThat(verificationCodeRepository.getByEmail(EMAIL)).isNotNull();
-    }
-
-    @Test
-    void 인증_코드를_인증할_수_있다() {
-        // given
-        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
-        doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-        // when
-        emailSender.sendMailAndGetVerificationCode(EMAIL);
-        String verificationCode = verificationCodeRepository.getByEmail(EMAIL);
-
-        // then
-        assertThatCode(
-            () -> emailSender.verifyCode(EMAIL, verificationCode)
-        ).doesNotThrowAnyException();
-    }
-
-    @Test
-    void 인증_코드가_틀린_경우_예외를_발생시킨다() {
-        // given
-        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
-        doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-        // when
-        emailSender.sendMailAndGetVerificationCode(EMAIL);
-
-        // then
-        assertThatThrownBy(
-            () -> emailSender.verifyCode(EMAIL, "WrongCode")
-        ).isInstanceOf(EmailVerificationCodeIncorrectException.class);
     }
 }

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/EmailVerificationServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/EmailVerificationServiceTest.java
@@ -3,61 +3,38 @@ package gdsc.binaryho.imhere.core.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
+import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
-import gdsc.binaryho.imhere.core.auth.exception.MessagingServerException;
 import gdsc.binaryho.imhere.mock.FakeVerificationCodeRepository;
-import javax.mail.Message.RecipientType;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mail.javamail.JavaMailSender;
 
-@ExtendWith(MockitoExtension.class)
 public class EmailVerificationServiceTest {
 
-    @Mock
-    JavaMailSender javaMailSender;
-
-    @Mock
-    MimeMessage mockMimeMessage;
-
+    boolean isMailSent;
+    MailSender mailSender = (recipient, verificationCode) -> isMailSent = true;
     VerificationCodeRepository verificationCodeRepository = new FakeVerificationCodeRepository();
-    EmailVerificationService emailVerificationService;
+
+    EmailVerificationService emailVerificationService =
+        new EmailVerificationService(mailSender, verificationCodeRepository);
 
     private static final String EMAIL = "dlwlsgh4687@gmail.com";
 
-    @BeforeEach
-    void initEmailSender() {
-        emailVerificationService = new EmailVerificationService(javaMailSender, verificationCodeRepository);
-    }
-
     @Test
-    void 회원가임_시도_이메일에_메일을_보낼_수_있다() {
+    void 인증코드와_메일을_보낼_수_있다() {
         // given
-        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
-        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+        isMailSent = false;
 
         // then
         emailVerificationService.sendMailAndGetVerificationCode(EMAIL);
 
         // then
-        verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+        assertThat(isMailSent).isTrue();
     }
 
     @ParameterizedTest
@@ -72,24 +49,8 @@ public class EmailVerificationServiceTest {
     }
 
     @Test
-    void 메시지_기록중_MessagingException_이_발생하는_경우_커스텀_예외인_MessagingServerException_발생() throws MessagingException {
-        // given
-        // when
-        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
-        doThrow(new MessagingException()).when(mockMimeMessage).addRecipients(RecipientType.TO, EMAIL);
-
-        // then
-        assertThatThrownBy(
-            () -> emailVerificationService.sendMailAndGetVerificationCode(EMAIL)
-        ).isInstanceOf(MessagingServerException.class);
-    }
-
-    @Test
     void 이메일_발송과_함께_인증_코드가_저장된다() {
         // given
-        given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
-        doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
         // when
         emailVerificationService.sendMailAndGetVerificationCode(EMAIL);
 
@@ -98,7 +59,7 @@ public class EmailVerificationServiceTest {
     }
 
     @Test
-    void 인증_코드를_인증할_수_있다() {
+    void 인증_코드를_검증할_수_있다() {
         // given
         String verificationCode = "imhere forever";
         verificationCodeRepository.saveWithEmailAsKey(EMAIL, verificationCode);


### PR DESCRIPTION
## What is this Pull Request about? 💬
이슈 -> #45

현재 이메일 인증 메일을 보낼 때 JavaMailSender를 EmailSender 클래스에서 바로 사용중이다.

이렇게 직접 사용하는 경우 EmailSender 서비스 테스트시 SMTP 서버를 사용하게 되거나, 실제로 메일이 날아갈 수도 있다.
Mocking을 할 수도 있었지만, 애초에 외부 의존성을 바로 쓰기 보단 의존성 역전을 통해 결합도를 낮추고 싶었고,
테스트에서 Mockito 의존성을 제거하면서 복잡한 Stubbing도 없애고 순수 자바 코드로 테스트를 진행하고 싶었다.

(JavaMailSender가 내부적으로 사용하는 MimeMessage 등으로 인해 Stubbing이 복잡하다.)

애초에 구체적인 기술을 바로 의존하는 방식은 설계 단계에서 기술에 국한된 설계를 유발하고,
결합도가 너무 높아진다.
실제로 변경 전 메일을 보내는 클래스가 복잡한 JavaMailSender 관련 코드들을 전부 가지고 있었다.

이에, JavaMailSender를 사용하는 로직을 따로 분리하고 Application Layer에 MailSender라는 인터페이스를 만들어 추상화 했다.
JavaMailSender를 이용하는 MailSender의 구현체 JavaMailSender는 (이름이 같다) Infrastructure Layer에 구현했다.

이후 EmailSender를 역할에 맞게 EmailVerificationService로 변경하고, MailSender를 의존하게 했다.
RedisTemplate를 사용중인 로직을 Repository로 추상화한 다음 
빈으로 관리해 의존성을 주입 받아 의존성을 역전하고, 영향을 받는 부분에 대한 테스트 코드를 작성했다.

<br>

## Key Changes 🔑
- Application Layer에 MailSender 인터페이스를 만들고 구현체 JavaMailSender를 Infrastructure Layer에 구현
- EmailSender에서 실제로 보내지는 메일에 포함되는 상수를 따로 상수 클래스에 분리
- EmailSender를 역할에 맞게 EmailVerificationService로 변경
- EmailVerificationService는 MailSender를 의존하도록 변경
- 변경된 코드에 맞게 EmailVerificationService 테스트 코드 작성

<br>