### PR TITLE
[refactor] TokenService의 SECTRET 값을 빈을 통해 주입 받도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.h2database:h2'
 
 	/* Security */
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/gdsc/binaryho/imhere/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/filter/JwtAuthorizationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         String jwtToken = request.getHeader(HEADER_STRING)
             .replace(ACCESS_TOKEN_PREFIX, "");
 
-        if (tokenService.validateTokenExpirationTime(jwtToken)) {
+        if (tokenService.validateTokenExpirationTimeNotExpired(jwtToken)) {
 
             String univId = tokenService.getUnivId(jwtToken);
             Member member = memberRepository.findByUnivId(univId).orElseThrow();

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/ImhereSecretHolder.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/ImhereSecretHolder.java
@@ -1,0 +1,16 @@
+package gdsc.binaryho.imhere.security.jwt;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImhereSecretHolder implements SecretHolder {
+
+    @Value("${jwt.access-token-prefix}")
+    private String SECRET;
+
+    @Override
+    public String getSecret() {
+        return SECRET;
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/SecretHolder.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/SecretHolder.java
@@ -1,0 +1,6 @@
+package gdsc.binaryho.imhere.security.jwt;
+
+public interface SecretHolder {
+
+    String getSecret();
+}

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -1,13 +1,16 @@
 package gdsc.binaryho.imhere.security.jwt;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 public class TokenService {
 
@@ -31,21 +34,20 @@ public class TokenService {
         );
     }
 
-    public boolean validateTokenExpirationTime(String token) {
-        if (token.isEmpty()) {
+    public boolean validateTokenExpirationTimeNotExpired(String token) {
+        if (token == null || token.isEmpty()) {
             return false;
         }
 
         try {
-            Jws<Claims> claims = Jwts.parser()
+            Jwts.parser()
                 .setSigningKey(SECRET)
                 .parseClaimsJws(token);
-
-            return claims.getBody()
-                .getExpiration()
-                .after(new Date());
-        } catch (Exception e) {
-            e.printStackTrace();
+            return true;
+        } catch (ExpiredJwtException exception) {
+            return false;
+        } catch (JwtException | IllegalArgumentException exception) {
+            log.info("[토큰 에러] {}", () -> exception.getMessage());
             return false;
         }
     }

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -5,6 +5,8 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -16,22 +18,27 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private final SecretHolder secretHolder;
-
     private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60L * 20L;
 
     public Token createToken(String univId, String roleKey) {
-        Claims memberClaims = Jwts.claims().setSubject(univId);
-        memberClaims.put("role", roleKey);
+        Claims claims = Jwts.claims().setSubject(univId);
+        claims.put("role", roleKey);
 
-        Date timeNow = new Date();
-        return new Token(
-            Jwts.builder()
-                .setClaims(memberClaims)
-                .setIssuedAt(timeNow)
-                .setExpiration(new Date(timeNow.getTime() + ACCESS_TOKEN_EXPIRATION_TIME))
-                .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
-                .compact()
-        );
+        long timeNowByMillis = getSeoulTimeNowByMillis();
+
+        String jwt = Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(new Date(timeNowByMillis))
+            .setExpiration(new Date(timeNowByMillis + ACCESS_TOKEN_EXPIRATION_TIME))
+            .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
+            .compact();
+
+        return new Token(jwt);
+    }
+
+    private long getSeoulTimeNowByMillis() {
+        ZonedDateTime seoulTimeNow = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        return seoulTimeNow.toInstant().toEpochMilli();
     }
 
     public boolean validateTokenExpirationTimeNotExpired(String token) {

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -6,16 +6,16 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Log4j2
 @Service
+@RequiredArgsConstructor
 public class TokenService {
 
-    @Value("${jwt.access-token-prefix}")
-    private String SECRET;
+    private final SecretHolder secretHolder;
 
     private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60L * 20L;
 
@@ -29,7 +29,7 @@ public class TokenService {
                 .setClaims(memberClaims)
                 .setIssuedAt(timeNow)
                 .setExpiration(new Date(timeNow.getTime() + ACCESS_TOKEN_EXPIRATION_TIME))
-                .signWith(SignatureAlgorithm.HS256, SECRET)
+                .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
                 .compact()
         );
     }
@@ -41,7 +41,7 @@ public class TokenService {
 
         try {
             Jwts.parser()
-                .setSigningKey(SECRET)
+                .setSigningKey(secretHolder.getSecret())
                 .parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException exception) {
@@ -54,7 +54,7 @@ public class TokenService {
 
     public String getUnivId(String token) {
         return Jwts.parser()
-            .setSigningKey(SECRET)
+            .setSigningKey(secretHolder.getSecret())
             .parseClaimsJws(token)
             .getBody()
             .getSubject();

--- a/src/test/java/gdsc/binaryho/imhere/mock/FakeSecretHolder.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/FakeSecretHolder.java
@@ -1,0 +1,17 @@
+package gdsc.binaryho.imhere.mock;
+
+import gdsc.binaryho.imhere.security.jwt.SecretHolder;
+
+public class FakeSecretHolder implements SecretHolder {
+
+    private final String secret;
+
+    public FakeSecretHolder(String secret) {
+        this.secret = secret;
+    }
+
+    @Override
+    public String getSecret() {
+        return secret;
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/mock/TestSecretHolder.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/TestSecretHolder.java
@@ -2,11 +2,11 @@ package gdsc.binaryho.imhere.mock;
 
 import gdsc.binaryho.imhere.security.jwt.SecretHolder;
 
-public class FakeSecretHolder implements SecretHolder {
+public class TestSecretHolder implements SecretHolder {
 
     private final String secret;
 
-    public FakeSecretHolder(String secret) {
+    public TestSecretHolder(String secret) {
         this.secret = secret;
     }
 

--- a/src/test/java/gdsc/binaryho/imhere/security/jwt/TokenServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/security/jwt/TokenServiceTest.java
@@ -5,16 +5,28 @@ import static gdsc.binaryho.imhere.fixture.MemberFixture.UNIV_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import gdsc.binaryho.imhere.mock.FakeSecretHolder;
+import gdsc.binaryho.imhere.mock.TestSecretHolder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 public class TokenServiceTest {
 
     private static final String SECRET = "TEST_SECRET";
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60L * 20L;
+    private static final long TIME_NOW = getTimeNowByMillis();
 
-    SecretHolder secretHolder = new FakeSecretHolder(SECRET);
+    public static long getTimeNowByMillis() {
+        ZonedDateTime seoulTimeNow = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        return seoulTimeNow.toInstant().toEpochMilli();
+    }
+
+    SecretHolder secretHolder = new TestSecretHolder(SECRET);
     TokenService tokenService = new TokenService(secretHolder);
 
     @Test
@@ -31,6 +43,105 @@ public class TokenServiceTest {
             () -> assertThat(claims.getSubject()).isEqualTo(UNIV_ID),
             () -> assertThat(claims.get("role")).isEqualTo(ROLE.getKey())
         );
+    }
+
+    @Test
+    void 토큰의_유효_시간의_만료_여부를_확인할_수_있다() {
+        // given
+        Claims claims = Jwts.claims().setSubject(UNIV_ID);
+
+        String jwt = Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(new Date(TIME_NOW))
+            .setExpiration(
+                new Date(TIME_NOW + ACCESS_TOKEN_EXPIRATION_TIME))
+            .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
+            .compact();
+        Token token = new Token(jwt);
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isNotNull();
+    }
+
+    @Test
+    void 토큰의_유효_시간이_만료되지_않은_경우_true를_반환한다() {
+        // given
+        Claims claims = Jwts.claims().setSubject(UNIV_ID);
+
+        String jwt = Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(new Date(TIME_NOW))
+            .setExpiration(
+                new Date(TIME_NOW + ACCESS_TOKEN_EXPIRATION_TIME))
+            .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
+            .compact();
+        Token token = new Token(jwt);
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isTrue();
+    }
+
+    @Test
+    void 토큰의_유효_시간이_만료된_경우_false를_반환한다() {
+        // given
+        Claims claims = Jwts.claims().setSubject(UNIV_ID);
+
+        String jwt = Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(new Date(TIME_NOW))
+            .setExpiration(
+                new Date(TIME_NOW + (-7777L)))
+            .signWith(SignatureAlgorithm.HS256, secretHolder.getSecret())
+            .compact();
+        Token token = new Token(jwt);
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isFalse();
+    }
+
+    @Test
+    void 토큰의_유효시간_만료를_확인할_떄_토큰이_null인_경우_false를_반환한다() {
+        // given
+        Token token = new Token(null);
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isFalse();
+    }
+
+    @Test
+    void 토큰의_유효시간_만료를_확인할_떄_토큰이_빈_문자열인_경우_false를_반환한다() {
+        // given
+        Token token = new Token("");
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isFalse();
+    }
+
+    @Test
+    void 토큰의_유효시간_만료를_확인할_떄_토큰이_유효하지_않은_문자열인_경우_false를_반환한다() {
+        // given
+        Token token = new Token(UUID.randomUUID().toString());
+
+        // when
+        // then
+        assertThat(
+            tokenService.validateTokenExpirationTimeNotExpired(token.getAccessToken()))
+            .isFalse();
     }
 
     @Test

--- a/src/test/java/gdsc/binaryho/imhere/security/jwt/TokenServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/security/jwt/TokenServiceTest.java
@@ -1,0 +1,45 @@
+package gdsc.binaryho.imhere.security.jwt;
+
+import static gdsc.binaryho.imhere.fixture.MemberFixture.ROLE;
+import static gdsc.binaryho.imhere.fixture.MemberFixture.UNIV_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import gdsc.binaryho.imhere.mock.FakeSecretHolder;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.Test;
+
+public class TokenServiceTest {
+
+    private static final String SECRET = "TEST_SECRET";
+
+    SecretHolder secretHolder = new FakeSecretHolder(SECRET);
+    TokenService tokenService = new TokenService(secretHolder);
+
+    @Test
+    void 이메일과_권한을_넣어_토큰을_만들_수_있다() {
+        Token token = tokenService.createToken(UNIV_ID, ROLE.getKey());
+        String accessToken = token.getAccessToken();
+
+        Claims claims = Jwts.parser()
+            .setSigningKey(secretHolder.getSecret())
+            .parseClaimsJws(accessToken)
+            .getBody();
+
+        assertAll(
+            () -> assertThat(claims.getSubject()).isEqualTo(UNIV_ID),
+            () -> assertThat(claims.get("role")).isEqualTo(ROLE.getKey())
+        );
+    }
+
+    @Test
+    void 토큰에서_UnivId를_추출할_수_있다() {
+        Token token = tokenService.createToken(UNIV_ID, ROLE.getKey());
+        String accessToken = token.getAccessToken();
+
+        String parsedUnivId = tokenService.getUnivId(accessToken);
+
+        assertThat(parsedUnivId).isEqualTo(UNIV_ID);
+    }
+}


### PR DESCRIPTION
## What is this Pull Request about? 💬
- TokenService는 토큰을 만들 때 사용하는 SECRET 값을 `@Value` 어노테이션을 사용해 설정파일에서 주입 받아 사용받았다.

![image](https://github.com/binary-ho/imhere-server/assets/71186266/d1cc0702-4a64-451a-be03-5edec6f35246)

토큰 값의 내용을 해석하려면 시크릿 값이 필요한데, 이런 식으로 바로 사용하는 경우, 
테스트시 캡슐화를 깨지 않으면서 시크릿 값을 사용하기가 어려웠다.

꼭 위와 같이 구현하지 않더라도, private final 로 선언했다면 똑같이 불편했을 것이다.

Secret Holder를 인터페이스로 만들어 구현체를 빈으로 만들어서 관리하겠다

<br>

## Key Changes 🔑


![image](https://github.com/binary-ho/imhere-server/assets/71186266/5189fb9f-196c-4e38-aeef-0ef972706ba5)

SecretHolder라는 인터페이스를 만들고, Secret 값을 가진 구현체를 빈으로 관리했다.

그리고 테스트용 Secret Holder를 만들어 테스트를 작성했다

![image](https://github.com/binary-ho/imhere-server/assets/71186266/f13b8c88-ab27-49fc-8926-aae845ac2453)

 - Token Service 만료시간 검증 메서드 이름 변경과 불필요한 검증 제거 및 로깅
 - Secret Holder 클래스 구현하여 적용
 - Token Service 테스트 코드 작성

<br>


