### PR TITLE
Redis Key Prefix 설정 (#60)

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/config/redis/RedisConfig.java
+++ b/src/main/java/gdsc/binaryho/imhere/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package gdsc.binaryho.imhere.config;
+package gdsc.binaryho.imhere.config.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/gdsc/binaryho/imhere/config/redis/RedisKeyPrefixes.java
+++ b/src/main/java/gdsc/binaryho/imhere/config/redis/RedisKeyPrefixes.java
@@ -2,6 +2,6 @@ package gdsc.binaryho.imhere.config.redis;
 
 public class RedisKeyPrefixes {
 
-    public static final String ATTENDANCE_NUMBER_KEY_PREFIX = "lecture_id$";
-    public static final String VERIFICATION_CODE_KEY_PREFIX = "email$";
+    public static final String ATTENDANCE_NUMBER_KEY_PREFIX = "$lecture_id$";
+    public static final String VERIFICATION_CODE_KEY_PREFIX = "$email$";
 }

--- a/src/main/java/gdsc/binaryho/imhere/config/redis/RedisKeyPrefixes.java
+++ b/src/main/java/gdsc/binaryho/imhere/config/redis/RedisKeyPrefixes.java
@@ -1,0 +1,7 @@
+package gdsc.binaryho.imhere.config.redis;
+
+public class RedisKeyPrefixes {
+
+    public static final String ATTENDANCE_NUMBER_KEY_PREFIX = "lecture_id$";
+    public static final String VERIFICATION_CODE_KEY_PREFIX = "email$";
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/infrastructure/AttendanceNumberRedisRepository.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.core.attendance.infrastructure;
 
+import gdsc.binaryho.imhere.config.redis.RedisKeyPrefixes;
 import gdsc.binaryho.imhere.core.attendance.application.port.AttendanceNumberRepository;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +12,14 @@ import org.springframework.stereotype.Repository;
 public class AttendanceNumberRedisRepository implements AttendanceNumberRepository {
 
     private static final Integer ATTENDANCE_NUMBER_EXPIRE_TIME = 10;
+    private static final String KEY_PREFIX = RedisKeyPrefixes.ATTENDANCE_NUMBER_KEY_PREFIX;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public Integer getByLectureId(Long lectureId) {
+        String queryKey = KEY_PREFIX + lectureId;
         String attendanceNumber = redisTemplate.opsForValue()
-            .get(lectureId.toString());
+            .get(queryKey);
 
         if (attendanceNumber == null) {
             return null;
@@ -27,8 +30,10 @@ public class AttendanceNumberRedisRepository implements AttendanceNumberReposito
 
     @Override
     public void saveWithLectureIdAsKey(Long lectureId, int attendanceNumber) {
+        String saveKey = KEY_PREFIX + lectureId;
+
         redisTemplate.opsForValue().set(
-            lectureId.toString(),
+            saveKey,
             String.valueOf(attendanceNumber),
             ATTENDANCE_NUMBER_EXPIRE_TIME,
             TimeUnit.MINUTES

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/VerificationCodeRedisRepository.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/infrastructure/VerificationCodeRedisRepository.java
@@ -1,5 +1,6 @@
 package gdsc.binaryho.imhere.core.auth.infrastructure;
 
+import gdsc.binaryho.imhere.config.redis.RedisKeyPrefixes;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -11,21 +12,21 @@ import org.springframework.stereotype.Repository;
 public class VerificationCodeRedisRepository implements VerificationCodeRepository {
 
     private static final Integer VERIFICATION_CODE_EXPIRE_TIME = 10;
+    private final String KEY_PREFIX = RedisKeyPrefixes.VERIFICATION_CODE_KEY_PREFIX;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public String getByEmail(String email) {
-        if (email == null) {
-            return null;
-        }
-
-        return redisTemplate.opsForValue().get(email);
+        String queryKey = KEY_PREFIX + email;
+        return redisTemplate.opsForValue().get(queryKey);
     }
 
     @Override
     public void saveWithEmailAsKey(String email, String verificationCode) {
+        String saveKey = KEY_PREFIX + email;
+
         redisTemplate.opsForValue().set(
-            email,
+            saveKey,
             verificationCode,
             VERIFICATION_CODE_EXPIRE_TIME,
             TimeUnit.MINUTES


### PR DESCRIPTION
## What is this Pull Request about? 💬
Redis에 저장되는 key들이 겹칠 수 있기 때문에, 
Redis에서 값을 저장하고 조회할 때 특수문자가 포함된 prefix를 설정해주었다.

특수문자를 포함하는 이유는 레디스에 key로써 저장되는 데이터 중에, 회원이 직접 입력하는 "이메일"이 있기 때문이다.
우연히 회원의 email이 prefix와 겹치거나 악의적으로 똑같이 적는 공격이 일어날 수도 있어서 특수문자를 포함했다.
유저의 이메일에는 특수문자를 포함할 수 없도록 미리 REGEX를 이용해 검증하고 있기 때문에, prefix에 특수문자만 포함해도 이 문제를 쉽게 해결할 수 있기 때문이다.
(나중에 사용될 가능성이 있는 uuid를 고려해, 특수문자에선 '-'는 제외했다.)

## Key Changes 🔑

- 현재 사용중인 Redis Reposiotry에서 데이터를 저장하고 조회할 때 prefix를 사용하도록 변경

<br>

