### PR TITLE
강의 최근 OPEN 시간 기록하기 #71

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
@@ -19,7 +19,7 @@ import gdsc.binaryho.imhere.core.lecture.exception.LectureNotOpenException;
 import gdsc.binaryho.imhere.core.lecture.infrastructure.LectureRepository;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
-import gdsc.binaryho.imhere.util.SeoulDateTime;
+import gdsc.binaryho.imhere.util.SeoulTimeHolder;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +38,7 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final EnrollmentInfoRepository enrollmentRepository;
     private final LectureRepository lectureRepository;
+    private final SeoulTimeHolder seoulTimeHolder;
 
     @Transactional
     public void takeAttendance(AttendanceRequest attendanceRequest, Long lectureId) {
@@ -59,7 +60,7 @@ public class AttendanceService {
             enrollmentInfo.getLecture(),
             attendanceRequest.getDistance(),
             attendanceRequest.getAccuracy(),
-            SeoulDateTime.from(attendanceRequest.getMilliseconds())
+            seoulTimeHolder.from(attendanceRequest.getMilliseconds())
         );
 
         attendanceRepository.save(attendance);
@@ -137,7 +138,7 @@ public class AttendanceService {
     }
 
     private LocalDateTime getTodaySeoulDateTime(Long milliseconds) {
-        return SeoulDateTime.from(milliseconds)
+        return seoulTimeHolder.from(milliseconds)
             .withHour(0).withMinute(0).withSecond(0);
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceService.java
@@ -19,7 +19,7 @@ import gdsc.binaryho.imhere.core.lecture.exception.LectureNotOpenException;
 import gdsc.binaryho.imhere.core.lecture.infrastructure.LectureRepository;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
-import gdsc.binaryho.imhere.util.SeoulTimeHolder;
+import gdsc.binaryho.imhere.util.SeoulDateTimeHolder;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +38,7 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final EnrollmentInfoRepository enrollmentRepository;
     private final LectureRepository lectureRepository;
-    private final SeoulTimeHolder seoulTimeHolder;
+    private final SeoulDateTimeHolder seoulDateTimeHolder;
 
     @Transactional
     public void takeAttendance(AttendanceRequest attendanceRequest, Long lectureId) {
@@ -60,7 +60,7 @@ public class AttendanceService {
             enrollmentInfo.getLecture(),
             attendanceRequest.getDistance(),
             attendanceRequest.getAccuracy(),
-            seoulTimeHolder.from(attendanceRequest.getMilliseconds())
+            seoulDateTimeHolder.from(attendanceRequest.getMilliseconds())
         );
 
         attendanceRepository.save(attendance);
@@ -138,7 +138,7 @@ public class AttendanceService {
     }
 
     private LocalDateTime getTodaySeoulDateTime(Long milliseconds) {
-        return seoulTimeHolder.from(milliseconds)
+        return seoulDateTimeHolder.from(milliseconds)
             .withHour(0).withMinute(0).withSecond(0);
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -19,6 +19,7 @@ import gdsc.binaryho.imhere.core.lecture.model.response.AttendanceNumberResponse
 import gdsc.binaryho.imhere.core.lecture.model.response.LectureResponse;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
+import gdsc.binaryho.imhere.util.SeoulDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -119,6 +120,7 @@ public class LectureService {
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.OPEN);
+        lecture.setLastOpeningTime(SeoulDateTime.getSeoulDateTime());
 
         int attendanceNumber = generateRandomNumber();
         saveOpenLecture(lecture, attendanceNumber);

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -51,7 +51,8 @@ public class LectureService {
     @Transactional
     public void createLecture(LectureCreateRequest request) {
         Member lecturer = authenticationHelper.getCurrentMember();
-        Lecture newLecture = Lecture.createLecture(lecturer, request.getLectureName());
+        Lecture newLecture = Lecture
+            .createLecture(lecturer, request.getLectureName(), seoulTimeHolder.getSeoulDateTime());
         lectureRepository.save(newLecture);
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -19,7 +19,7 @@ import gdsc.binaryho.imhere.core.lecture.model.response.AttendanceNumberResponse
 import gdsc.binaryho.imhere.core.lecture.model.response.LectureResponse;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
-import gdsc.binaryho.imhere.util.SeoulDateTime;
+import gdsc.binaryho.imhere.util.SeoulTimeHolder;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +45,8 @@ public class LectureService {
     private final AttendeeCacheRepository attendeeCacheRepository;
 
     private final ApplicationEventPublisher eventPublisher;
+
+    private final SeoulTimeHolder seoulTimeHolder;
 
     @Transactional
     public void createLecture(LectureCreateRequest request) {
@@ -120,7 +122,7 @@ public class LectureService {
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.OPEN);
-        lecture.setLastOpeningTime(SeoulDateTime.getSeoulDateTime());
+        lecture.setLastOpeningTime(seoulTimeHolder.getSeoulDateTime());
 
         int attendanceNumber = generateRandomNumber();
         saveOpenLecture(lecture, attendanceNumber);

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -19,7 +19,7 @@ import gdsc.binaryho.imhere.core.lecture.model.response.AttendanceNumberResponse
 import gdsc.binaryho.imhere.core.lecture.model.response.LectureResponse;
 import gdsc.binaryho.imhere.core.member.Member;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
-import gdsc.binaryho.imhere.util.SeoulTimeHolder;
+import gdsc.binaryho.imhere.util.SeoulDateTimeHolder;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -46,13 +46,13 @@ public class LectureService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    private final SeoulTimeHolder seoulTimeHolder;
+    private final SeoulDateTimeHolder seoulDateTimeHolder;
 
     @Transactional
     public void createLecture(LectureCreateRequest request) {
         Member lecturer = authenticationHelper.getCurrentMember();
         Lecture newLecture = Lecture
-            .createLecture(lecturer, request.getLectureName(), seoulTimeHolder.getSeoulDateTime());
+            .createLecture(lecturer, request.getLectureName(), seoulDateTimeHolder.getSeoulDateTime());
         lectureRepository.save(newLecture);
     }
 
@@ -123,7 +123,7 @@ public class LectureService {
         authenticationHelper.verifyRequestMemberLogInMember(lecture.getMember().getId());
 
         lecture.setLectureState(LectureState.OPEN);
-        lecture.setLastOpeningTime(seoulTimeHolder.getSeoulDateTime());
+        lecture.setLastOpeningTime(seoulDateTimeHolder.getSeoulDateTime());
 
         int attendanceNumber = generateRandomNumber();
         saveOpenLecture(lecture, attendanceNumber);

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/domain/Lecture.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/domain/Lecture.java
@@ -3,6 +3,8 @@ package gdsc.binaryho.imhere.core.lecture.domain;
 
 import gdsc.binaryho.imhere.core.lecture.LectureState;
 import gdsc.binaryho.imhere.core.member.Member;
+import gdsc.binaryho.imhere.util.SeoulDateTime;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -40,12 +42,15 @@ public class Lecture {
     @Enumerated(EnumType.STRING)
     private LectureState lectureState;
 
+    private LocalDateTime lastOpeningTime;
+
     public static Lecture createLecture(Member lecturer, String lectureName) {
         Lecture lecture = new Lecture();
         lecture.setMember(lecturer);
         lecture.setLectureName(lectureName);
         lecture.setLecturerName(lecturer.getName());
         lecture.setLectureState(LectureState.CLOSED);
+        lecture.setLastOpeningTime(SeoulDateTime.getSeoulDateTime());
         return lecture;
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/domain/Lecture.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/domain/Lecture.java
@@ -3,7 +3,6 @@ package gdsc.binaryho.imhere.core.lecture.domain;
 
 import gdsc.binaryho.imhere.core.lecture.LectureState;
 import gdsc.binaryho.imhere.core.member.Member;
-import gdsc.binaryho.imhere.util.SeoulDateTime;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -44,13 +43,13 @@ public class Lecture {
 
     private LocalDateTime lastOpeningTime;
 
-    public static Lecture createLecture(Member lecturer, String lectureName) {
+    public static Lecture createLecture(Member lecturer, String lectureName, LocalDateTime createdAt) {
         Lecture lecture = new Lecture();
         lecture.setMember(lecturer);
         lecture.setLectureName(lectureName);
         lecture.setLecturerName(lecturer.getName());
         lecture.setLectureState(LectureState.CLOSED);
-        lecture.setLastOpeningTime(SeoulDateTime.getSeoulDateTime());
+        lecture.setLastOpeningTime(createdAt);
         return lecture;
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -24,7 +24,7 @@ public class TokenService {
         Claims claims = Jwts.claims().setSubject(univId);
         claims.put("role", roleKey);
 
-        long seoulTimeNow = SeoulDateTime.getMillisecondsNow();
+        long seoulTimeNow = SeoulDateTime.getSeoulMilliseconds();
 
         String jwt = Jwts.builder()
             .setClaims(claims)

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -1,6 +1,6 @@
 package gdsc.binaryho.imhere.security.jwt;
 
-import gdsc.binaryho.imhere.util.SeoulDateTime;
+import gdsc.binaryho.imhere.util.SeoulTimeHolder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -18,13 +18,15 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private final SecretHolder secretHolder;
+    private final SeoulTimeHolder seoulTimeHolder;
+
     private static final Duration ACCESS_TOKEN_EXPIRATION_TIME = Duration.ofMinutes(30);
 
     public Token createToken(String univId, String roleKey) {
         Claims claims = Jwts.claims().setSubject(univId);
         claims.put("role", roleKey);
 
-        long seoulTimeNow = SeoulDateTime.getSeoulMilliseconds();
+        long seoulTimeNow = seoulTimeHolder.getSeoulMilliseconds();
 
         String jwt = Jwts.builder()
             .setClaims(claims)

--- a/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/jwt/TokenService.java
@@ -1,6 +1,6 @@
 package gdsc.binaryho.imhere.security.jwt;
 
-import gdsc.binaryho.imhere.util.SeoulTimeHolder;
+import gdsc.binaryho.imhere.util.SeoulDateTimeHolder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private final SecretHolder secretHolder;
-    private final SeoulTimeHolder seoulTimeHolder;
+    private final SeoulDateTimeHolder seoulDateTimeHolder;
 
     private static final Duration ACCESS_TOKEN_EXPIRATION_TIME = Duration.ofMinutes(30);
 
@@ -26,7 +26,7 @@ public class TokenService {
         Claims claims = Jwts.claims().setSubject(univId);
         claims.put("role", roleKey);
 
-        long seoulTimeNow = seoulTimeHolder.getSeoulMilliseconds();
+        long seoulTimeNow = seoulDateTimeHolder.getSeoulMilliseconds();
 
         String jwt = Jwts.builder()
             .setClaims(claims)

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
@@ -9,6 +9,10 @@ public class SeoulDateTime {
 
     private static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    public static LocalDateTime getSeoulDateTime() {
+        return LocalDateTime.now(SEOUL_ZONE_ID);
+    }
+
     public static long getMillisecondsNow() {
         LocalDateTime seoulDateTime = LocalDateTime.now(SEOUL_ZONE_ID);
         return getMillisecondsFrom(seoulDateTime);

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
@@ -7,7 +7,7 @@ import java.time.ZoneOffset;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SeoulDateTime implements SeoulTimeHolder {
+public class SeoulDateTime implements SeoulDateTimeHolder {
 
     private static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
 

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
@@ -13,7 +13,7 @@ public class SeoulDateTime {
         return LocalDateTime.now(SEOUL_ZONE_ID);
     }
 
-    public static long getMillisecondsNow() {
+    public static long getSeoulMilliseconds() {
         LocalDateTime seoulDateTime = LocalDateTime.now(SEOUL_ZONE_ID);
         return getMillisecondsFrom(seoulDateTime);
     }

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTime.java
@@ -4,26 +4,28 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import org.springframework.stereotype.Component;
 
-public class SeoulDateTime {
+@Component
+public class SeoulDateTime implements SeoulTimeHolder {
 
     private static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
 
-    public static LocalDateTime getSeoulDateTime() {
+    public LocalDateTime getSeoulDateTime() {
         return LocalDateTime.now(SEOUL_ZONE_ID);
     }
 
-    public static long getSeoulMilliseconds() {
+    public long getSeoulMilliseconds() {
         LocalDateTime seoulDateTime = LocalDateTime.now(SEOUL_ZONE_ID);
         return getMillisecondsFrom(seoulDateTime);
     }
 
-    public static long getMillisecondsFrom(LocalDateTime localDateTime) {
+    public long getMillisecondsFrom(LocalDateTime localDateTime) {
         return localDateTime
             .toInstant(ZoneOffset.UTC).toEpochMilli();
     }
 
-    public static LocalDateTime from(long milliseconds) {
+    public LocalDateTime from(long milliseconds) {
         return LocalDateTime
             .ofInstant(Instant.ofEpochMilli(milliseconds), SEOUL_ZONE_ID);
     }

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTimeHolder.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulDateTimeHolder.java
@@ -2,7 +2,7 @@ package gdsc.binaryho.imhere.util;
 
 import java.time.LocalDateTime;
 
-public interface SeoulTimeHolder {
+public interface SeoulDateTimeHolder {
 
     LocalDateTime getSeoulDateTime();
 

--- a/src/main/java/gdsc/binaryho/imhere/util/SeoulTimeHolder.java
+++ b/src/main/java/gdsc/binaryho/imhere/util/SeoulTimeHolder.java
@@ -1,0 +1,14 @@
+package gdsc.binaryho.imhere.util;
+
+import java.time.LocalDateTime;
+
+public interface SeoulTimeHolder {
+
+    LocalDateTime getSeoulDateTime();
+
+    long getSeoulMilliseconds();
+
+    long getMillisecondsFrom(LocalDateTime localDateTime);
+
+    LocalDateTime from(long milliseconds);
+}

--- a/src/test/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/attendance/application/AttendanceServiceTest.java
@@ -35,9 +35,9 @@ import gdsc.binaryho.imhere.core.lecture.domain.OpenLecture;
 import gdsc.binaryho.imhere.core.lecture.exception.LectureNotOpenException;
 import gdsc.binaryho.imhere.core.lecture.infrastructure.LectureRepository;
 import gdsc.binaryho.imhere.core.member.Role;
+import gdsc.binaryho.imhere.mock.FixedSeoulTimeHolder;
 import gdsc.binaryho.imhere.mock.TestContainer;
 import gdsc.binaryho.imhere.mock.securitycontext.MockSecurityContextMember;
-import gdsc.binaryho.imhere.util.SeoulDateTime;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
@@ -234,7 +234,7 @@ public class AttendanceServiceTest {
     @MockSecurityContextMember(id = 2L, role = Role.LECTURER)
     void 강사는_지정_날짜의_출석_정보를_가져올_수_있다() {
         // given
-        LocalDateTime dayLocalDateTime = SeoulDateTime.from(MILLISECONDS)
+        LocalDateTime dayLocalDateTime = new FixedSeoulTimeHolder().from(MILLISECONDS)
             .withHour(0).withMinute(0).withSecond(0);
 
         // 위에서 구한 LocalDateTime 이용

--- a/src/test/java/gdsc/binaryho/imhere/mock/FixedSeoulTimeHolder.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/FixedSeoulTimeHolder.java
@@ -1,0 +1,35 @@
+package gdsc.binaryho.imhere.mock;
+
+import gdsc.binaryho.imhere.util.SeoulDateTimeHolder;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public class FixedSeoulTimeHolder implements SeoulDateTimeHolder {
+
+    public static final LocalDateTime FIXED_LOCAL_DATE_TIME = LocalDateTime.now();
+//        LocalDateTime
+//        .of(2023, Month.MAY, 6, 11, 0, 0);
+
+    public static final Long FIXED_MILLISECONDS = FIXED_LOCAL_DATE_TIME
+        .toInstant(ZoneOffset.UTC).toEpochMilli();
+
+    @Override
+    public LocalDateTime getSeoulDateTime() {
+        return FIXED_LOCAL_DATE_TIME;
+    }
+
+    @Override
+    public long getSeoulMilliseconds() {
+        return FIXED_MILLISECONDS;
+    }
+
+    @Override
+    public long getMillisecondsFrom(LocalDateTime localDateTime) {
+        return FIXED_MILLISECONDS;
+    }
+
+    @Override
+    public LocalDateTime from(long milliseconds) {
+        return FIXED_LOCAL_DATE_TIME;
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
@@ -18,6 +18,7 @@ import gdsc.binaryho.imhere.mock.fakerepository.FakeAttendeeCacheRepository;
 import gdsc.binaryho.imhere.mock.fakerepository.FakeOpenLectureCacheRepository;
 import gdsc.binaryho.imhere.mock.fakerepository.FakeVerificationCodeRepository;
 import gdsc.binaryho.imhere.security.util.AuthenticationHelper;
+import gdsc.binaryho.imhere.util.SeoulDateTimeHolder;
 import lombok.Builder;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -39,6 +40,7 @@ public class TestContainer {
     private final MailSender mailSender = (recipient, verificationCode) -> isMailSent = true;
     private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
     private final AuthenticationHelper authenticationHelper = new AuthenticationHelper();
+    private final SeoulDateTimeHolder seoulDateTimeHolder = new FixedSeoulTimeHolder();
 
     @Builder
     public TestContainer(
@@ -65,12 +67,12 @@ public class TestContainer {
 
         /* Attendance ervice 초기화 */
         attendanceService = new AttendanceService(
-            authenticationHelper, openLectureService, attendanceRepository, enrollmentInfoRepository, lectureRepository
+            authenticationHelper, openLectureService, attendanceRepository, enrollmentInfoRepository, lectureRepository, seoulDateTimeHolder
         );
 
         /* LectureService 초기화 */
         lectureService = new LectureService(
-            authenticationHelper, lectureRepository, enrollmentInfoRepository, openLectureCacheRepository, attendeeCacheRepository, applicationEventPublisher
+            authenticationHelper, lectureRepository, enrollmentInfoRepository, openLectureCacheRepository, attendeeCacheRepository, applicationEventPublisher, seoulDateTimeHolder
         );
     }
 }

--- a/src/test/java/gdsc/binaryho/imhere/mock/fixture/AttendanceFixture.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/fixture/AttendanceFixture.java
@@ -1,7 +1,7 @@
 package gdsc.binaryho.imhere.mock.fixture;
 
 import gdsc.binaryho.imhere.core.attendance.Attendance;
-import gdsc.binaryho.imhere.util.SeoulDateTime;
+import gdsc.binaryho.imhere.mock.FixedSeoulTimeHolder;
 import java.time.LocalDateTime;
 
 public class AttendanceFixture {
@@ -16,6 +16,6 @@ public class AttendanceFixture {
         MemberFixture.MOCK_STUDENT, LectureFixture.MOCK_LECTURE, DISTANCE, ACCURACY, LOCAL_DATE_TIME);
 
     private static LocalDateTime getLocalDateTime() {
-        return SeoulDateTime.from(MILLISECONDS);
+        return new FixedSeoulTimeHolder().from(MILLISECONDS);
     }
 }

--- a/src/test/java/gdsc/binaryho/imhere/mock/fixture/LectureFixture.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/fixture/LectureFixture.java
@@ -2,6 +2,7 @@ package gdsc.binaryho.imhere.mock.fixture;
 
 import gdsc.binaryho.imhere.core.lecture.LectureState;
 import gdsc.binaryho.imhere.core.lecture.domain.Lecture;
+import gdsc.binaryho.imhere.mock.FixedSeoulTimeHolder;
 
 public class LectureFixture {
 
@@ -10,20 +11,23 @@ public class LectureFixture {
     public static final Lecture MOCK_CLOSED_LECTURE = getMockClosedLecture();
 
     private static Lecture getMockLecture() {
-        Lecture lecture = Lecture.createLecture(MemberFixture.MOCK_LECTURER, "mockLecture");
+        Lecture lecture = Lecture.createLecture(
+            MemberFixture.MOCK_LECTURER, "mockLecture", FixedSeoulTimeHolder.FIXED_LOCAL_DATE_TIME);
         lecture.setId(1L);
         return lecture;
     }
 
     private static Lecture getMockOpenLecture() {
-        Lecture lecture = Lecture.createLecture(MemberFixture.MOCK_LECTURER, "MockOpenLecture");
+        Lecture lecture = Lecture.createLecture(
+            MemberFixture.MOCK_LECTURER, "MockOpenLecture", FixedSeoulTimeHolder.FIXED_LOCAL_DATE_TIME);
         lecture.setId(2L);
         lecture.setLectureState(LectureState.OPEN);
         return lecture;
     }
 
     private static Lecture getMockClosedLecture() {
-        Lecture lecture = Lecture.createLecture(MemberFixture.MOCK_LECTURER, "MockClosedLecture");
+        Lecture lecture = Lecture.createLecture(
+            MemberFixture.MOCK_LECTURER, "MockClosedLecture", FixedSeoulTimeHolder.FIXED_LOCAL_DATE_TIME);
         lecture.setId(3L);
         lecture.setLectureState(LectureState.CLOSED);
         return lecture;


### PR DESCRIPTION
## What is this Pull Request about? 💬
1. Lecture에 Last Opening Time이라는 최근 OPEN 시간 필드를 추가
2. 강의 생성과 OPEN시 last opening time을 update하도록 변경
3. 이 과정에서, 기존 SeoulDateTime가 실제 서울 현재 시간을 반환하기 때문에, 테스트 하기가 어려워 SeoulDateTimeHolder로 추상화 하고, 빈으로 관리 (의존성 역전)
4. 테스트시엔 SeoulDateTimeHolder를 구현한 FixedDateTimeHolder를 사용해 테스트 (고정 상수 시간을 반환한다)
5. DB 스키마 변경 <br>
```sql
ALTER TABLE lectures ADD COLUMN last_opening_time TIMESTAMPTZ DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Seoul');
```

6. 강의를 닫는 프로시저 생성
```sql
CREATE OR REPLACE PROCEDURE close_open_lectures()
LANGUAGE plpgsql
AS $$
BEGIN
    UPDATE lectures
    SET lecture_state = 'CLOSED'
    WHERE lecture_state = 'OPEN' AND last_opening_time <= (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Seoul') - INTERVAL '10 minutes';
END;
$$;
```

7. postgresql cron을 통해 프로시저 3분 단위 호출 스케줄링
8. dev 환경 테스트를 통해 직접 테스트 하여 직접 확인
9. 테스트 가능한 범위는 테스트 코드 작성
