### PR TITLE
이메일 인증 과정 전에 중복 이메일 검사 #73

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
 
     @Transactional
     public void signUp(String univId, String name, String password) {
-        validateDuplicateMember(univId);
+        validateMemberNotExist(univId);
         validatePasswordForm(password);
 
         Member newMember = Member.createMember(univId, name, bCryptPasswordEncoder.encode(password), Role.STUDENT);
@@ -36,7 +36,7 @@ public class AuthService {
         memberRepository.save(newMember);
     }
 
-    private void validateDuplicateMember(String univId) {
+    public void validateMemberNotExist(String univId) {
         if (memberRepository.findByUnivId(univId).isPresent()) {
             log.info("[회원가입 실패] univId 중복 회원가입 시도 univId : " + univId);
             throw DuplicateEmailException.EXCEPTION;

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -29,7 +29,8 @@ public class EmailVerificationService {
         mailSender.sendEmailWithVerificationCode(recipient, verificationCode);
         saveVerificationCodeWithRecipientAsKey(recipient, verificationCode);
 
-        log.info("[인증 이메일 발송] " + recipient + ", 인증 번호 : " + verificationCode);
+        log.info("[인증 이메일 발송] {}, 인증 번호 : {}",
+            () -> recipient, () -> verificationCode);
     }
 
     private void validateEmailForm(String recipient) {
@@ -43,9 +44,18 @@ public class EmailVerificationService {
     }
 
     public void verifyCode(String email, String verificationCode) {
-        String emailVerificationCode = verificationCodeRepository.getByEmail(email);
-        if (!Objects.equals(emailVerificationCode, verificationCode)) {
+        String savedVerificationCode = verificationCodeRepository.getByEmail(email);
+        if (!Objects.equals(savedVerificationCode, verificationCode)) {
+            logEmailVerificationFail(email, verificationCode, savedVerificationCode);
+
             throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
+        log.info("[이메일 인증 성공] email : {}", () -> email);
+    }
+
+    private void logEmailVerificationFail(String email, String verificationCode,
+        String savedVerificationCode) {
+        log.info("[이메일 인증 실패] email : {}, 제출 코드 : {}, 저장된 코드 : {}",
+            () -> email, () -> verificationCode, () -> savedVerificationCode);
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -18,10 +18,12 @@ public class EmailVerificationService {
     private static final String EMAIL_REGEX = "^[a-zA-Z0-9]+@(?:(?:g\\.)?hongik\\.ac\\.kr)$";
     private static final String GMAIL_REGEX = "^[a-zA-Z0-9]+@gmail\\.com$";
 
+    private final AuthService authService;
     private final MailSender mailSender;
     private final VerificationCodeRepository verificationCodeRepository;
 
     public void sendMailAndGetVerificationCode(String recipient) {
+        authService.validateMemberNotExist(recipient);
         validateEmailForm(recipient);
 
         String verificationCode = UUID.randomUUID().toString();


### PR DESCRIPTION
1. 이메일을 기입하고, 검증 단계로 넘어가기 전에 이미 가입한 이메일이라면, 예외를 발생시켜서 회원에게 알리는 기능 구현.
2. 이메일 인증 성공-실패 로그가 없어서 추가