### PR TITLE
[feature] 비밀번호 변경 구현 #74

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -4,6 +4,8 @@ import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
+import gdsc.binaryho.imhere.core.auth.model.request.SendPasswordChangeEmailRequest;
+import gdsc.binaryho.imhere.core.auth.model.request.SendSignUpEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SignInRequest;
 import gdsc.binaryho.imhere.core.auth.model.response.SignInRequestValidationResult;
 import gdsc.binaryho.imhere.core.member.Member;
@@ -48,14 +50,28 @@ public class AuthService {
     }
 
     @Transactional
-    public void sendSignUpEmail(String recipient) {
-        validateMemberNotExist(recipient);
-        emailVerificationService.sendVerificationCodeByEmail(recipient);
+    public void sendSignUpEmail(SendSignUpEmailRequest request) {
+        validateMemberNotExist(request.getEmail());
+        emailVerificationService.sendVerificationCodeByEmail(request.getEmail());
+    }
+
+    @Transactional
+    public void sendPasswordChangeEmail(SendPasswordChangeEmailRequest request) {
+        validateMemberExist(request.getEmail());
+        emailVerificationService.sendVerificationCodeByEmail(request.getEmail());
     }
 
     private void validateMemberNotExist(String email) {
         if (memberRepository.findByUnivId(email).isPresent()) {
             log.info("[회원가입 실패] 중복 이메일 회원가입 시도 -> univId : " + email);
+            throw DuplicateEmailException.EXCEPTION;
+        }
+    }
+
+    private void validateMemberExist(String email) {
+        if (memberRepository.findByUnivId(email).isEmpty()) {
+            log.info(
+                "[비밀번호 변경 시도 실패] 가입하지 않은 회원이 비밀번호 변경 요청 -> email : {}" + email);
             throw DuplicateEmailException.EXCEPTION;
         }
     }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -115,7 +115,7 @@ public class AuthService {
     }
 
     private void validateRequestPasswordsAreEqual(String newPassword, String confirmationPassword) {
-        if (Objects.equals(newPassword, confirmationPassword)) {
+        if (!Objects.equals(newPassword, confirmationPassword)) {
             throw PasswordsNotEqualException.EXCEPTION;
         }
     }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -16,15 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
-    private final AuthService authService;
     private final MailSender mailSender;
     private final EmailFormValidator emailFormValidator;
 
     private final VerificationCodeRepository verificationCodeRepository;
 
-    @Transactional
     public void sendVerificationCodeByEmail(String recipient) {
-        authService.validateMemberNotExist(recipient);
         emailFormValidator.validateEmailForm(recipient);
 
         String verificationCode = UUID.randomUUID().toString();

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -3,7 +3,6 @@ package gdsc.binaryho.imhere.core.auth.application;
 import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
-import gdsc.binaryho.imhere.core.auth.model.request.VerifyEmailRequest;
 import gdsc.binaryho.imhere.core.auth.util.EmailFormValidator;
 import java.util.Objects;
 import java.util.UUID;
@@ -39,11 +38,10 @@ public class EmailVerificationService {
     }
 
     @Transactional(readOnly = true)
-    public void verifyCode(VerifyEmailRequest verifyEmailRequest) {
-        String email = verifyEmailRequest.getEmail();
+    public void verifyCode(String email, String verificationCode) {
         String savedVerificationCode = verificationCodeRepository.getByEmail(email);
 
-        validateEmailCodeMatching(savedVerificationCode, verifyEmailRequest.getVerificationCode(), email);
+        validateEmailCodeMatching(savedVerificationCode, verificationCode, email);
         log.info("[이메일 인증 성공] email : {}", () -> email);
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -3,6 +3,7 @@ package gdsc.binaryho.imhere.core.auth.application;
 import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
+import gdsc.binaryho.imhere.core.auth.model.request.VerifyEmailRequest;
 import gdsc.binaryho.imhere.core.auth.util.EmailFormValidator;
 import java.util.Objects;
 import java.util.UUID;
@@ -38,14 +39,19 @@ public class EmailVerificationService {
     }
 
     @Transactional(readOnly = true)
-    public void verifyCode(String email, String verificationCode) {
+    public void verifyCode(VerifyEmailRequest verifyEmailRequest) {
+        String email = verifyEmailRequest.getEmail();
         String savedVerificationCode = verificationCodeRepository.getByEmail(email);
-        if (!Objects.equals(savedVerificationCode, verificationCode)) {
-            logEmailVerificationFail(email, verificationCode, savedVerificationCode);
 
+        validateEmailCodeMatching(savedVerificationCode, verifyEmailRequest.getVerificationCode(), email);
+        log.info("[이메일 인증 성공] email : {}", () -> email);
+    }
+
+    private void validateEmailCodeMatching(String savedVerificationCode, String requestVerificationCode, String email) {
+        if (!Objects.equals(savedVerificationCode, requestVerificationCode)) {
+            logEmailVerificationFail(email, requestVerificationCode, savedVerificationCode);
             throw EmailVerificationCodeIncorrectException.EXCEPTION;
         }
-        log.info("[이메일 인증 성공] email : {}", () -> email);
     }
 
     private void logEmailVerificationFail(String email, String verificationCode,

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service
@@ -21,7 +22,8 @@ public class EmailVerificationService {
 
     private final VerificationCodeRepository verificationCodeRepository;
 
-    public void sendMailAndGetVerificationCode(String recipient) {
+    @Transactional
+    public void sendVerificationCodeByEmail(String recipient) {
         authService.validateMemberNotExist(recipient);
         emailFormValidator.validateEmailForm(recipient);
 
@@ -38,6 +40,7 @@ public class EmailVerificationService {
         verificationCodeRepository.saveWithEmailAsKey(recipient, verificationCode);
     }
 
+    @Transactional(readOnly = true)
     public void verifyCode(String email, String verificationCode) {
         String savedVerificationCode = verificationCodeRepository.getByEmail(email);
         if (!Objects.equals(savedVerificationCode, verificationCode)) {

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationService.java
@@ -2,8 +2,8 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
-import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
+import gdsc.binaryho.imhere.core.auth.util.EmailFormValidator;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,16 +15,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
-    private static final String EMAIL_REGEX = "^[a-zA-Z0-9]+@(?:(?:g\\.)?hongik\\.ac\\.kr)$";
-    private static final String GMAIL_REGEX = "^[a-zA-Z0-9]+@gmail\\.com$";
-
     private final AuthService authService;
     private final MailSender mailSender;
+    private final EmailFormValidator emailFormValidator;
+
     private final VerificationCodeRepository verificationCodeRepository;
 
     public void sendMailAndGetVerificationCode(String recipient) {
         authService.validateMemberNotExist(recipient);
-        validateEmailForm(recipient);
+        emailFormValidator.validateEmailForm(recipient);
 
         String verificationCode = UUID.randomUUID().toString();
 
@@ -33,12 +32,6 @@ public class EmailVerificationService {
 
         log.info("[인증 이메일 발송] {}, 인증 번호 : {}",
             () -> recipient, () -> verificationCode);
-    }
-
-    private void validateEmailForm(String recipient) {
-        if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
-            throw EmailFormatMismatchException.EXCEPTION;
-        }
     }
 
     private void saveVerificationCodeWithRecipientAsKey(String recipient, String verificationCode) {

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     @Operation(summary = "특정 이메일로 회원가입 코드를 발급하여 발송하는 API")
     @PostMapping("/verification/{email}")
     public ResponseEntity<Void> generateVerificationNumber(@PathVariable("email") String email) {
-        emailVerificationService.sendMailAndGetVerificationCode(email);
+        authService.sendSignUpEmail(email);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -5,13 +5,13 @@ import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
 import gdsc.binaryho.imhere.core.auth.model.request.SendPasswordChangeEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SendSignUpEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
+import gdsc.binaryho.imhere.core.auth.model.request.VerifyEmailRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,10 +56,9 @@ public class AuthController {
     }
 
     @Operation(summary = "특정 이메일에 발급된 회원가입 코드와 입력된 코드의 일치여부를 확인하는 API")
-    @GetMapping("/verification/{email}/{verification-code}")
-    public ResponseEntity<Void> verifyCode(@PathVariable("email") String email,
-        @PathVariable("verification-code") String verificationCode) {
-        emailVerificationService.verifyCode(email, verificationCode);
+    @GetMapping("/verification")
+    public ResponseEntity<Void> verifyCode(@RequestBody VerifyEmailRequest verifyEmailRequest) {
+        emailVerificationService.verifyCode(verifyEmailRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package gdsc.binaryho.imhere.core.auth.controller;
 
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
 import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
+import gdsc.binaryho.imhere.core.auth.model.request.SendPasswordChangeEmailRequest;
+import gdsc.binaryho.imhere.core.auth.model.request.SendSignUpEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,6 +27,10 @@ public class AuthController {
     private final AuthService authService;
     private final EmailVerificationService emailVerificationService;
 
+    private static final String TYPE = "type=";
+    private static final String SIGN_UP = TYPE + "sign-up";
+    private static final String PASSWORD_CHANGE = TYPE + "password-change";
+
     @Operation(summary = "회원가입 API")
     @PostMapping("/new")
     public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
@@ -33,10 +39,19 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "특정 이메일로 회원가입 코드를 발급하여 발송하는 API")
-    @PostMapping("/verification/{email}")
-    public ResponseEntity<Void> generateVerificationNumber(@PathVariable("email") String email) {
-        authService.sendSignUpEmail(email);
+    @Operation(summary = "회원가입을 위한 인증 코드와 이메일 발송 API")
+    @PostMapping(value = "/verification", params = SIGN_UP)
+    public ResponseEntity<Void> sendSignUpEmail(
+        @RequestBody SendSignUpEmailRequest sendVerificationEmailRequest) {
+        authService.sendSignUpEmail(sendVerificationEmailRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 변경을 위한 인증 코드와 이메일 발송 API")
+    @PostMapping(value = "/verification", params = PASSWORD_CHANGE)
+    public ResponseEntity<Void> sendPasswordChangeEmail(
+        @RequestBody SendPasswordChangeEmailRequest sendVerificationEmailRequest) {
+        authService.sendPasswordChangeEmail(sendVerificationEmailRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package gdsc.binaryho.imhere.core.auth.controller;
 
 import gdsc.binaryho.imhere.core.auth.application.AuthService;
 import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
+import gdsc.binaryho.imhere.core.auth.model.request.ChangePasswordRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SendPasswordChangeEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SendSignUpEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
@@ -42,23 +43,31 @@ public class AuthController {
     @Operation(summary = "회원가입을 위한 인증 코드와 이메일 발송 API")
     @PostMapping(value = "/verification", params = SIGN_UP)
     public ResponseEntity<Void> sendSignUpEmail(
-        @RequestBody SendSignUpEmailRequest sendVerificationEmailRequest) {
-        authService.sendSignUpEmail(sendVerificationEmailRequest);
+        @RequestBody SendSignUpEmailRequest sendSignUpEmailRequest) {
+        authService.sendSignUpEmail(sendSignUpEmailRequest);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "비밀번호 변경을 위한 인증 코드와 이메일 발송 API")
     @PostMapping(value = "/verification", params = PASSWORD_CHANGE)
     public ResponseEntity<Void> sendPasswordChangeEmail(
-        @RequestBody SendPasswordChangeEmailRequest sendVerificationEmailRequest) {
-        authService.sendPasswordChangeEmail(sendVerificationEmailRequest);
+        @RequestBody SendPasswordChangeEmailRequest sendPasswordChangeEmailRequest) {
+        authService.sendPasswordChangeEmail(sendPasswordChangeEmailRequest);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "특정 이메일에 발급된 회원가입 코드와 입력된 코드의 일치여부를 확인하는 API")
     @GetMapping("/verification")
     public ResponseEntity<Void> verifyCode(@RequestBody VerifyEmailRequest verifyEmailRequest) {
-        emailVerificationService.verifyCode(verifyEmailRequest);
+        emailVerificationService.verifyCode(
+            verifyEmailRequest.getEmail(), verifyEmailRequest.getVerificationCode());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 변경 API")
+    @PostMapping("/password")
+    public ResponseEntity<Void> changePassword(@RequestBody ChangePasswordRequest changePasswordRequest) {
+        authService.changePassword(changePasswordRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordNullException.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordNullException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.core.auth.exception;
+
+import gdsc.binaryho.imhere.exception.ErrorInfo;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordNullException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordNullException();
+
+    private PasswordNullException() {
+        super(ErrorInfo.PASSWORD_NULL_EXCEPTION);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordsNotEqualException.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordsNotEqualException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.core.auth.exception;
+
+import gdsc.binaryho.imhere.exception.ErrorInfo;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordsNotEqualException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordsNotEqualException();
+
+    private PasswordsNotEqualException() {
+        super(ErrorInfo.PASSWORDS_NOT_EQUAL);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/ChangePasswordRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/ChangePasswordRequest.java
@@ -1,0 +1,17 @@
+package gdsc.binaryho.imhere.core.auth.model.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChangePasswordRequest {
+
+    private String email;
+    private String verificationCode;
+    private String newPassword;
+    private String confirmationPassword;
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SendPasswordChangeEmailRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SendPasswordChangeEmailRequest.java
@@ -1,0 +1,14 @@
+package gdsc.binaryho.imhere.core.auth.model.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SendPasswordChangeEmailRequest {
+
+    private String email;
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SendSignUpEmailRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/SendSignUpEmailRequest.java
@@ -1,0 +1,14 @@
+package gdsc.binaryho.imhere.core.auth.model.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SendSignUpEmailRequest {
+
+    private String email;
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/VerifyEmailRequest.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/model/request/VerifyEmailRequest.java
@@ -1,0 +1,14 @@
+package gdsc.binaryho.imhere.core.auth.model.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class VerifyEmailRequest {
+    private String email;
+    private String verificationCode;
+}

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailFormValidator.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/util/EmailFormValidator.java
@@ -1,0 +1,17 @@
+package gdsc.binaryho.imhere.core.auth.util;
+
+import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailFormValidator {
+
+    private static final String EMAIL_REGEX = "^[a-zA-Z0-9]+@(?:(?:g\\.)?hongik\\.ac\\.kr)$";
+    private static final String GMAIL_REGEX = "^[a-zA-Z0-9]+@gmail\\.com$";
+
+    public void validateEmailForm(String recipient) {
+        if (!recipient.matches(EMAIL_REGEX) && !recipient.matches(GMAIL_REGEX)) {
+            throw EmailFormatMismatchException.EXCEPTION;
+        }
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
@@ -16,6 +16,8 @@ public enum ErrorInfo {
     REQUEST_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, 1006, "요청 형식이 맞지 않습니다."),
     EMAIL_VERIFICATION_CODE_INCORRECT(HttpStatus.BAD_REQUEST, 1007, "Email 인증 번호가 불일치합니다."),
     MESSAGING_SERVER_EXCEPTION(HttpStatus.NOT_FOUND, 1008, "Messaging Server 에 연결할 수 없습니다."),
+    PASSWORD_NULL_EXCEPTION(HttpStatus.BAD_REQUEST, 1009, "비밀번호 변경 요청시 보내온 비밀번호가 비어 있습니다."),
+    PASSWORDS_NOT_EQUAL(HttpStatus.BAD_REQUEST, 1010, "비밀번호 변경 요청시 보내온 새 비밀번호와 확인용 비밀번호가 불일치합니다."),
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "강의 정보가 없습니다."),
     LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 2002, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),
@@ -29,7 +31,7 @@ public enum ErrorInfo {
 
     REQUEST_MEMBER_ID_MISMATCH(HttpStatus.BAD_REQUEST, 9001, "실제로 요청을 보낸 유저의 id와 Request에 기재된 id가 다릅니다. (악의적 요청)"),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, 9002, "유저가 권한이 없는 요청을 보냈습니다. (악의적 요청)"),
-    UNEXPECTED_REDIS_DATA_TYPE(HttpStatus.NOT_FOUND, 9003, "수강생 정보에 이상이 있어 캐싱할 수 없습니다. (문의 주세요)")
+    UNEXPECTED_REDIS_DATA_TYPE(HttpStatus.NOT_FOUND, 9003, "수강생 정보에 이상이 있어 캐싱할 수 없습니다. (문의 주세요)"),
 
     ;
 

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailFormValidatorTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailFormValidatorTest.java
@@ -1,0 +1,28 @@
+package gdsc.binaryho.imhere.core.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
+import gdsc.binaryho.imhere.core.auth.util.EmailFormValidator;
+import gdsc.binaryho.imhere.mock.TestContainer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class EmailFormValidatorTest {
+
+    EmailFormValidator emailFormValidator = TestContainer
+        .builder()
+        .build()
+        .emailFormValidator;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"naver.com", "mail.hongik.ac.kr", "g.hongik.ac.k", "gmail.net"})
+    void 홍익대학교_이메일이나_구글_이메일이_아닌_경우_예외가_발생한다(String postfix) {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() ->
+            emailFormValidator.validateEmailForm("test@" + postfix))
+            .isInstanceOf(EmailFormatMismatchException.class);
+    }
+}

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
@@ -8,15 +8,12 @@ import static org.mockito.BDDMockito.given;
 
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
-import gdsc.binaryho.imhere.core.auth.exception.EmailFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
 import gdsc.binaryho.imhere.mock.TestContainer;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -53,17 +50,6 @@ public class EmailVerificationServiceTest {
 
         // then
         assertThat(testContainer.isMailSent).isTrue();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"naver.com", "mail.hongik.ac.kr", "g.hongik.ac.k", "gmail.net"})
-    void 홍익대학교_이메일이나_구글_이메일이_아닌_경우_예외가_발생한다(String postfix) {
-        // given
-        // when
-        // then
-        assertThatThrownBy(() ->
-            emailVerificationService.sendMailAndGetVerificationCode("test@" + postfix))
-            .isInstanceOf(EmailFormatMismatchException.class);
     }
 
     @Test

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
@@ -1,17 +1,13 @@
 package gdsc.binaryho.imhere.core.auth.application;
 
-import static gdsc.binaryho.imhere.mock.fixture.MemberFixture.MOCK_STUDENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
-import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
 import gdsc.binaryho.imhere.core.auth.exception.EmailVerificationCodeIncorrectException;
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
 import gdsc.binaryho.imhere.mock.TestContainer;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -46,29 +42,17 @@ public class EmailVerificationServiceTest {
         testContainer.isMailSent = false;
 
         // then
-        emailVerificationService.sendMailAndGetVerificationCode(EMAIL);
+        emailVerificationService.sendVerificationCodeByEmail(EMAIL);
 
         // then
         assertThat(testContainer.isMailSent).isTrue();
     }
 
     @Test
-    void 이미_가입한_이메일로_인증_요청시_예와가_발생한다() {
-        // given
-        given(memberRepository.findByUnivId(EMAIL)).willReturn(Optional.of(MOCK_STUDENT));
-
-        // then
-        // then
-        assertThatThrownBy(() ->
-            emailVerificationService.sendMailAndGetVerificationCode(EMAIL))
-            .isInstanceOf(DuplicateEmailException.class);
-    }
-
-    @Test
     void 이메일_발송과_함께_인증_코드가_저장된다() {
         // given
         // when
-        emailVerificationService.sendMailAndGetVerificationCode(EMAIL);
+        emailVerificationService.sendVerificationCodeByEmail(EMAIL);
 
         // then
         assertThat(verificationCodeRepository.getByEmail(EMAIL)).isNotNull();

--- a/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
@@ -6,6 +6,7 @@ import gdsc.binaryho.imhere.core.auth.application.AuthService;
 import gdsc.binaryho.imhere.core.auth.application.EmailVerificationService;
 import gdsc.binaryho.imhere.core.auth.application.port.MailSender;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
+import gdsc.binaryho.imhere.core.auth.util.EmailFormValidator;
 import gdsc.binaryho.imhere.core.enrollment.application.EnrollmentService;
 import gdsc.binaryho.imhere.core.enrollment.infrastructure.EnrollmentInfoRepository;
 import gdsc.binaryho.imhere.core.lecture.application.LectureService;
@@ -41,6 +42,7 @@ public class TestContainer {
     private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
     private final AuthenticationHelper authenticationHelper = new AuthenticationHelper();
     private final SeoulDateTimeHolder seoulDateTimeHolder = new FixedSeoulTimeHolder();
+    public final EmailFormValidator emailFormValidator = new EmailFormValidator();
 
     @Builder
     public TestContainer(
@@ -56,7 +58,7 @@ public class TestContainer {
         );
 
         /* EmailVerificationService 초기화 */
-        emailVerificationService = new EmailVerificationService(mailSender, verificationCodeRepository);
+        emailVerificationService = new EmailVerificationService(authService, mailSender, emailFormValidator, verificationCodeRepository);
 
         /* OpenLectureService 초기화 */
         openLectureService = new OpenLectureService(openLectureCacheRepository);

--- a/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
@@ -39,9 +39,10 @@ public class TestContainer {
 
     public boolean isMailSent = false;
     private final MailSender mailSender = (recipient, verificationCode) -> isMailSent = true;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
     private final AuthenticationHelper authenticationHelper = new AuthenticationHelper();
     private final SeoulDateTimeHolder seoulDateTimeHolder = new FixedSeoulTimeHolder();
+
+    public final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
     public final EmailFormValidator emailFormValidator = new EmailFormValidator();
 
     @Builder

--- a/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
+++ b/src/test/java/gdsc/binaryho/imhere/mock/TestContainer.java
@@ -52,13 +52,13 @@ public class TestContainer {
         AttendanceRepository attendanceRepository,
         ApplicationEventPublisher applicationEventPublisher) {
 
+        /* EmailVerificationService 초기화 */
+        emailVerificationService = new EmailVerificationService(mailSender, emailFormValidator, verificationCodeRepository);
+
         /* AuthService 초기화 */
         authService = new AuthService(
-            memberRepository, bCryptPasswordEncoder
+            emailVerificationService, memberRepository, bCryptPasswordEncoder
         );
-
-        /* EmailVerificationService 초기화 */
-        emailVerificationService = new EmailVerificationService(authService, mailSender, emailFormValidator, verificationCodeRepository);
 
         /* OpenLectureService 초기화 */
         openLectureService = new OpenLectureService(openLectureCacheRepository);


### PR DESCRIPTION
새 학기를 맞아 비밀번호 변경 기능이 필요하다는 요청이 들어와서 비밀번호 변경 기능을 구현하다가, 이메일 인증 관련 API를 전부 뜯어 고쳤다.

다음 부터는 꼭 따로 이슈와 PR을 열어야겠다. 후회중이다

# 변경점과 이유
1. 인증 이메일 발송을 이메일 서비스가 직접 수행하지 않고 AuthService가 수행 <br> -> 회원가입시 이메일 인증은 **가입한 화원이 없는지** 확인해야 했고, 비밀번호 인증시엔 **가입한 회원이 있다는 것을** 확인해야 했다. <br> 이런 상황에서 EmailService가 이런 역할을 수행하기엔 AuthService가 수행하는 것이 더 적절해 보였다. <br> 문제는 AuthService가 이미 EmailSerivce를 의존하는 부분이 있어, **서비스 순환참조가 발생할 수도 있었다.**  <br> 다양한 해결법이 있겠지만, 앞으로 이메일 발송 로직을 AuthSerivce가 검증과 함께 처리하고, AuthService가 단방향으로 EmailVerificationService를 사용하도록 변경했다
2. 이메일 변경 API를 구현했다.
3. url 구분이 어려워 기존 이메일 검증 API들의 url에서 이메일과 검증 점보를 떼어내고, type이라는 파라미터로 검증 메서드를 구분하게 만들었다. 그리고 관련 API들이 Request 객체를 받도록 변경했다
4. 관련된 모든 부분에 대한 테스트를 수정하고, <Br> 새로운 기능들에 대한 테스트를 추가했다