### PR TITLE
GET Method에 Request Body 제거 (#79)

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/controller/AuthController.java
@@ -6,13 +6,13 @@ import gdsc.binaryho.imhere.core.auth.model.request.ChangePasswordRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SendPasswordChangeEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SendSignUpEmailRequest;
 import gdsc.binaryho.imhere.core.auth.model.request.SignUpRequest;
-import gdsc.binaryho.imhere.core.auth.model.request.VerifyEmailRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,7 +40,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "회원가입을 위한 인증 코드와 이메일 발송 API")
+    @Operation(summary = "회원가입을 위한 인증 코드와 이메일 발송 API", tags = SIGN_UP)
     @PostMapping(value = "/verification", params = SIGN_UP)
     public ResponseEntity<Void> sendSignUpEmail(
         @RequestBody SendSignUpEmailRequest sendSignUpEmailRequest) {
@@ -48,7 +48,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "비밀번호 변경을 위한 인증 코드와 이메일 발송 API")
+    @Operation(summary = "비밀번호 변경을 위한 인증 코드와 이메일 발송 API", tags = PASSWORD_CHANGE)
     @PostMapping(value = "/verification", params = PASSWORD_CHANGE)
     public ResponseEntity<Void> sendPasswordChangeEmail(
         @RequestBody SendPasswordChangeEmailRequest sendPasswordChangeEmailRequest) {
@@ -57,10 +57,10 @@ public class AuthController {
     }
 
     @Operation(summary = "특정 이메일에 발급된 회원가입 코드와 입력된 코드의 일치여부를 확인하는 API")
-    @GetMapping("/verification")
-    public ResponseEntity<Void> verifyCode(@RequestBody VerifyEmailRequest verifyEmailRequest) {
-        emailVerificationService.verifyCode(
-            verifyEmailRequest.getEmail(), verifyEmailRequest.getVerificationCode());
+    @GetMapping("/verification/{email}/{verification-code}")
+    public ResponseEntity<Void> verifyCode(@PathVariable("email") String email,
+        @PathVariable("verification-code") String verificationCode) {
+        emailVerificationService.verifyCode(email, verificationCode);
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
지난 비밀번호 변경 기능 구현때 이메일 검증 GET 메서드에 Request Body를 추가했다. 
원래 GET에는 BODY를 추가할 수 없지만, 필요에 의해 추가할 수도 있다고 생각하여 넣었다. 
만들 떄의 의도는 지금 생각해보면 바보같다.

하지만 js 라이브러리 Axios에선 get 메서드에 애초에 페이로드를 넣을 수 없다. 
이에, verify 메서드를 원래대로 파라미터에서 값을 추출하도록 변경한다.