### PR TITLE
[refactor] 비밀번호 변경시 가입하지 않은 회원일 경우 새로운 Exception 반환

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
+import gdsc.binaryho.imhere.core.auth.exception.PasswordChangeMemberNotExistException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordNullException;
@@ -89,7 +90,7 @@ public class AuthService {
         if (memberRepository.findByUnivId(email).isEmpty()) {
             log.info(
                 "[비밀번호 변경 시도 실패] 가입하지 않은 회원이 비밀번호 변경 요청 -> email : {}" + email);
-            throw DuplicateEmailException.EXCEPTION;
+            throw PasswordChangeMemberNotExistException.EXCEPTION;
         }
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordChangeMemberNotExistException.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordChangeMemberNotExistException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.core.auth.exception;
+
+import gdsc.binaryho.imhere.exception.ErrorInfo;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordChangeMemberNotExistException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordChangeMemberNotExistException();
+
+    private PasswordChangeMemberNotExistException() {
+        super(ErrorInfo.PASSWORD_CHANGE_MEMBER_NOT_EXIST);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
@@ -18,6 +18,7 @@ public enum ErrorInfo {
     MESSAGING_SERVER_EXCEPTION(HttpStatus.NOT_FOUND, 1008, "Messaging Server 에 연결할 수 없습니다."),
     PASSWORD_NULL_EXCEPTION(HttpStatus.BAD_REQUEST, 1009, "비밀번호 변경 요청시 보내온 비밀번호가 비어 있습니다."),
     PASSWORDS_NOT_EQUAL(HttpStatus.BAD_REQUEST, 1010, "비밀번호 변경 요청시 보내온 새 비밀번호와 확인용 비밀번호가 불일치합니다."),
+    PASSWORD_CHANGE_MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, 1011, "비밀번호 변경을 시도한 이메일을 소유한 회원이 없습니다."),
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "강의 정보가 없습니다."),
     LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 2002, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),


### PR DESCRIPTION
## What is this Pull Request about? 💬
현재 비밀번호 변경시 없는 회원일 때 내려주는 예외가 기존에 다른 곳에서 사용하던 예외이다.
이렇게 하는 경우 클라이언트에서 에러 응답에 대한 공통 처리를 하기가 어려워진다.
새로 만드는거 얼마나 걸린다고, 중복 사용을 해버렸다.

애초에 이런 에러 코드 만드는 것이 클라이언트 분들이 더 쉽게 예외 처리를 할 수 있도록 하는데에 목적이 있는데,
너무 후회된다.

비밀번호 변경시 가입하지 않은 회원인 경우에 새로운 에러를 만들어 반환해주자.

<br>

## Key Changes 🔑
1. PASSWORD_CHANGE_MEMBER_NOT_EXIST 구현 (NOT_FOUND 에러)
2. 비밀번호 변경시 가입하지 않은 회원일 경우 PasswordChangeMemberNotExistException 발생
3. 클라이언트에는 PASSWORD_CHANGE_MEMBER_NOT_EXIST 반환