### PR TITLE
비밀번호 변경시 가입하지 않은 회원일 경우에 대한 테스트 코드 변경 #81

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package gdsc.binaryho.imhere.core.auth.application;
 
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
+import gdsc.binaryho.imhere.core.auth.exception.PasswordChangeMemberNotExistException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordNullException;
@@ -89,7 +90,7 @@ public class AuthService {
         if (memberRepository.findByUnivId(email).isEmpty()) {
             log.info(
                 "[비밀번호 변경 시도 실패] 가입하지 않은 회원이 비밀번호 변경 요청 -> email : {}" + email);
-            throw DuplicateEmailException.EXCEPTION;
+            throw PasswordChangeMemberNotExistException.EXCEPTION;
         }
     }
 

--- a/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordChangeMemberNotExistException.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/auth/exception/PasswordChangeMemberNotExistException.java
@@ -1,0 +1,13 @@
+package gdsc.binaryho.imhere.core.auth.exception;
+
+import gdsc.binaryho.imhere.exception.ErrorInfo;
+import gdsc.binaryho.imhere.exception.ImhereException;
+
+public class PasswordChangeMemberNotExistException extends ImhereException {
+
+    public static final ImhereException EXCEPTION = new PasswordChangeMemberNotExistException();
+
+    private PasswordChangeMemberNotExistException() {
+        super(ErrorInfo.PASSWORD_CHANGE_MEMBER_NOT_EXIST);
+    }
+}

--- a/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
+++ b/src/main/java/gdsc/binaryho/imhere/exception/ErrorInfo.java
@@ -18,6 +18,7 @@ public enum ErrorInfo {
     MESSAGING_SERVER_EXCEPTION(HttpStatus.NOT_FOUND, 1008, "Messaging Server 에 연결할 수 없습니다."),
     PASSWORD_NULL_EXCEPTION(HttpStatus.BAD_REQUEST, 1009, "비밀번호 변경 요청시 보내온 비밀번호가 비어 있습니다."),
     PASSWORDS_NOT_EQUAL(HttpStatus.BAD_REQUEST, 1010, "비밀번호 변경 요청시 보내온 새 비밀번호와 확인용 비밀번호가 불일치합니다."),
+    PASSWORD_CHANGE_MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, 1011, "비밀번호 변경을 시도한 이메일을 소유한 회원이 없습니다."),
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "강의 정보가 없습니다."),
     LECTURE_NOT_OPEN(HttpStatus.FORBIDDEN, 2002, "강의에 출석 가능한 상태가 아닙니다. (Lecture Not OPEN)"),

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/AuthServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/AuthServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import gdsc.binaryho.imhere.core.auth.application.port.VerificationCodeRepository;
 import gdsc.binaryho.imhere.core.auth.exception.DuplicateEmailException;
 import gdsc.binaryho.imhere.core.auth.exception.MemberNotFoundException;
+import gdsc.binaryho.imhere.core.auth.exception.PasswordChangeMemberNotExistException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordFormatMismatchException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordIncorrectException;
 import gdsc.binaryho.imhere.core.auth.exception.PasswordNullException;
@@ -215,7 +216,7 @@ class AuthServiceTest {
         // then
         assertThatThrownBy(
             () -> authService.changePassword(changePasswordRequest)
-        ).isInstanceOf(MemberNotFoundException.class);
+        ).isInstanceOf(PasswordChangeMemberNotExistException.class);
     }
 
     @Test


### PR DESCRIPTION
## What is this Pull Request about? 💬
- 비밀번호 변경시 존재하지 않는 회원인 경우 예외를 반환하는 피처의 PR에 테스트 코드 반영 부분이 누락되었다
<br> 

이런 식으로 빼먹은 습관은 나쁘다. 테스트를 하지 않으면 통합할 수 없는 장치를 마련해야겠다.

<br>

## Key Changes 🔑
- 비밀번호 변경시 가입하지 않은 회원일 경우에 대한 테스트 코드 변경

