### PR TITLE
feat : PR open, reopen, synchronized, closed시 gradle build test를 수행하는 job 추가 (#88)

### DIFF
--- a/.github/workflows/pull-request-gradle-build-test.yml
+++ b/.github/workflows/pull-request-gradle-build-test.yml
@@ -1,0 +1,37 @@
+name : 풀 리퀘스트 Gradle 빌드 테스트
+
+on:
+  pull_request:
+    types: [opened, reopen, synchronize, closed]
+
+permissions: read-all
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3.0.2
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            application:
+              - 'build.gradle'
+              - 'src/**'
+
+      - name: JDK 설치
+        if: steps.changes.outputs.application == 'true'
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: 'gradle'
+      - name: Gradle Build
+        if: steps.changes.outputs.application == 'true'
+        run: |
+          ./gradlew build --no-build-cache


### PR DESCRIPTION
## What is this Pull Request about? 💬
분명 확인했다고 생각했는데, 테스트에 통과하지 못한 브랜치를 merge하는 일이 벌써 두 번이나 생겼다.
매번 확인하기 까다로우니 깃허브 Action을 이용해 PR open, reopen, merge, closed 시 테스트를 진행하도록 설정해 줬다.

자바 11을 이용해 빌드하고, src 내 파일이나,  gradle build 파일 변경시 테스트하도록 했다.


```yml
name : 풀 리퀘스트 Gradle 빌드 테스트

on:
  pull_request:
    types: [opened, reopen, synchronize, closed]

permissions: read-all

jobs:
  build-test:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pull-requests: write
    steps:
      - name: Git Checkout
        uses: actions/checkout@v3.0.2

      - uses: dorny/paths-filter@v2
        id: changes
        with:
          filters: |
            application:
              - 'build.gradle'
              - 'src/**'

      - name: JDK 설치
        if: steps.changes.outputs.application == 'true'
        uses: actions/setup-java@v3
        with:
          distribution: zulu
          java-version: 11
          cache: 'gradle'
      - name: Gradle Build
        if: steps.changes.outputs.application == 'true'
        run: |
          ./gradlew build --no-build-cache

```