### PR TITLE
🚀 [feature] Jasypt를 통해 암호화된 yaml 파일 도입 #94

### DIFF
--- a/.github/workflows/pull-request-gradle-build-test.yml
+++ b/.github/workflows/pull-request-gradle-build-test.yml
@@ -37,5 +37,7 @@ jobs:
         
       - name: Gradle Build
         if: steps.changes.outputs.application == 'true'
+        env:
+          JASYPT_ENCRYPTION_PASSWORD: ${{ secrets.PROPERTY_ENCRYPTION_PASSWORD }}
         run: |
           ./gradlew build --no-build-cache

--- a/.gitignore
+++ b/.gitignore
@@ -35,16 +35,13 @@ out/
 
 ### VS Code ###
 .vscode/
-/src/**/application.yml
-/src/**/application*.yml
-
-### Project ###
-/src/main/java/gdsc/binaryho/imhere/initDB.java
-/docker-compose**
 
 ### logs ###
 /log
 /logs
 
-### test ###
-/src/main/java/gdsc/binaryho/imhere/test/
+### imhere ###
+/src/**/*-original*
+/src/test/java/gdsc/binaryho/imhere/dev
+/src/main/java/gdsc/binaryho/imhere/dev
+/docker-compose**

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
 
 	/* swagger */
 	implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
+
+	/* jasypt */
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/gdsc/binaryho/imhere/config/EncryptorConfig.java
+++ b/src/main/java/gdsc/binaryho/imhere/config/EncryptorConfig.java
@@ -1,0 +1,24 @@
+package gdsc.binaryho.imhere.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EncryptorConfig {
+
+    @Bean("propertyEncryptor")
+    public StringEncryptor stringEncryptor(@Value(value = "${jasypt.secret-key}") String encryptorPassword) {
+        PooledPBEStringEncryptor pooledPBEStringEncryptor = new PooledPBEStringEncryptor();
+
+        SimpleStringPBEConfig simpleStringPBEConfig = new SimpleStringPBEConfig();
+        simpleStringPBEConfig.setPassword(encryptorPassword);
+        simpleStringPBEConfig.setPoolSize(1);
+
+        pooledPBEStringEncryptor.setConfig(simpleStringPBEConfig);
+        return pooledPBEStringEncryptor;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,46 @@
+server:
+  port: 8081
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    url: ENC(SLtFvRkjnLTEOXCKwOWTieAHkexxxxwPbANXTfXgNbYN8lzp/Y67eKcwaECzYrBVZVRfddSnUkOcXR784eB7UA42pTw6UVyJqMIpBSJecniWbyBVpyA7EWWEG65ZJntygxQ/qL2kAdE=)
+    username: ENC(97015VsffcgI0f3/4wkIRF83s66KSbgB)
+    password: ENC(k9/r7urCpjm1zejJNalPZ+CnqEuf3b/r9t+66h8bZVw=)
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+      dialect: -- org.hibernate.dialect.PostgreSQLDialect
+
+    properties:
+      hibernate:
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+
+# mock member data
+mock-member:
+  prefix:
+    id: ENC(6N3LMH1t9ar6rUbXACXPsyPu4aQGwMrR)
+    name: ENC(685ObShtyTVVKv2e6GmGby9qqnT3+pxF)
+    password: ENC(M2kfFT/j6wSbRsOoUDghmBoriIe68D5fnz4pjXPdULw=)
+
+# Cors
+origin:
+  domain: ENC(qEH+jjdnQ3ckzkLvUD4mVK+UkjWtnkTc67x4hQF4ySM=)
+
+# log
+logging:
+  config: classpath:log4j2-dev.xml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: ENC(5zqShAjVmyJ2d45bahY29W9iJjjlaopZCiHWBQDmnGsysvfNPhV+8r1iA2w18NWLVUfctiS5Z4a/l3/QLay6MEIdE1DUkhsATbpZrDyy7lrHCGX/r2KxIhzEwE093+dadkERKLhDtIs=)
+    username: ENC(97015VsffcgI0f3/4wkIRF83s66KSbgB)
+    password: ENC(k9/r7urCpjm1zejJNalPZ+CnqEuf3b/r9t+66h8bZVw=)
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+      dialect: -- org.hibernate.dialect.PostgreSQLDialect
+
+admin:
+  univ-id: END(MnnJJNaW4by9rR1oo90AfA==)
+  name: END(74r3AHMoJBHegbbayNVTRbM3GACH/df5)
+  password: END(syprHyAFiPy50LqxoNeK5B3dPZ3g4tZdgslnAjARey8=)
+
+# cors
+origin:
+  domain: END(QLDNT2IEA8b20N6/HcY+7CltriZvLqwaG8AWh24TZ0E=)
+
+logging:
+  config: classpath:log4j2-prod.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+spring:
+  redis:
+    host: redis
+    port: 6379
+    password: ENC(QDFGW5huIiRsK9z8tmV6ng==)
+
+  jpa:
+    open-in-view: false
+
+jwt:
+  secret: ENC(Wi5BD1R9VNidIJj2xI10Ww==)
+  prefix: "Bearer "
+  header-string: "Authorization"
+  access-token-prefix: "Token "
+
+# SMTP
+mail:
+  smtp:
+    auth: true
+    starttls:
+      required: true
+      enable: true
+
+    socketFactory:
+      class: javax.net.ssl.SSLSocketFactory
+      fallback: false
+      port: 465
+
+    port: 465
+
+# admin 구글 계정
+AdminMail:
+  id: ENC(wPQnA6wFGpeuODHjXHm/eyKNUXNq694VH2G97+jWDSU=)
+  password: ENC(aRfl+HHF9UNK0z2TRkQ53cuUw/3OcYElfHNMWTCD51Q=)
+
+jasypt:
+  encryptor:
+    bean: propertyEncryptor
+  secret-key: ${JASYPT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,4 +36,4 @@ AdminMail:
 jasypt:
   encryptor:
     bean: propertyEncryptor
-  secret-key: ${JASYPT_SECRET_KEY}
+  secret-key: ${JASYPT_ENCRYPTION_PASSWORD}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -70,4 +70,4 @@ origin:
 jasypt:
   encryptor:
     bean: propertyEncryptor
-  secret-key: ${JASYPT_SECRET_KEY}
+  secret-key: ${JASYPT_ENCRYPTION_PASSWORD}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,73 @@
+server:
+  port: 8081
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  profiles:
+    active: test
+
+  jpa:
+    open-in-view: false
+
+# 원본
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:~/mem-data;
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+
+  redis:
+    host: localhost
+    port: 6378
+    password: ENC(t9qeZ6WjZb8nTCX6USgT0Q==)
+
+jwt:
+  secret: ENC(Wi5BD1R9VNidIJj2xI10Ww==)
+  prefix: "Bearer "
+  header-string: "Authorization"
+  access-token-prefix: "Token "
+
+admin:
+  univ-id: ENC(MnnJJNaW4by9rR1oo90AfA==)
+  name: ENC(74r3AHMoJBHegbbayNVTRbM3GACH/df5)
+  password: ENC(syprHyAFiPy50LqxoNeK5B3dPZ3g4tZdgslnAjARey8=)
+
+
+# SMTP
+mail:
+  smtp:
+    auth: true
+    starttls:
+      required: true
+      enable: true
+
+    socketFactory:
+      class: javax.net.ssl.SSLSocketFactory
+      fallback: false
+      port: 465
+
+    port: 465
+
+# admin 구글 계정
+AdminMail:
+  id: ENC(wPQnA6wFGpeuODHjXHm/eyKNUXNq694VH2G97+jWDSU=)
+  password: ENC(aRfl+HHF9UNK0z2TRkQ53cuUw/3OcYElfHNMWTCD51Q=)
+
+# Cors
+origin:
+  domain: ENC(QLDNT2IEA8b20N6/HcY+7CltriZvLqwaG8AWh24TZ0E=)
+  test: ENC(qEH+jjdnQ3ckzkLvUD4mVK+UkjWtnkTc67x4hQF4ySM=)
+
+jasypt:
+  encryptor:
+    bean: propertyEncryptor
+  secret-key: ${JASYPT_SECRET_KEY}


### PR DESCRIPTION
## What is this Pull Request about? 💬

현재까지 혼자 백엔드를 구현하며 yml 파일을 github에 올릴 이유가 딱히 없었다.
하지만, PR 만들고 업데이트 하는 과정에 gradle build를 추가하면서 올릴 필요가 생겼다.
왜냐하면 이제 gradle build시 테스트 과정에서 test시 yml 파일에 있는 다양한 설정값들을 필요로 하기 때문이다.

여러 선택지 중에서 많이 고민했다.
yml 파일의 숨기고 싶은 값들을 Github Secret으로 숨기는 작업을 많이 하는것 같았는데, 나는 마음에 들지 않았다.
값이 바뀔 일이 많지는 않겠지만, 매번 코드와 깃허브를 오가며 값을 수정하거나
추가할 때도 번거로워 보였다.

Jasypt는 Jasypt에 사용할 비밀번호 하나만 깃허브 시크릿으로 관리해주면 될 것 같아서 편해보였다.

<br>

## Key Changes 🔑

- Jaspty 의존성 추가
- Jasypt String Encryptor 빈 생성
- **yaml 파일 중요 프로퍼티 암호화**
- yaml 파일에 Jasypt 관련 설정 추가
- gitignore에서 yaml 파일 제거
- 깃허브 시크릿에 Jasypt 패스워드 값 추가
- pull requet gradle build test의 빌드 과정 환경변수로 Jasypt 패스워드 값 추가