### PR TITLE
refactor : Service Test 불필요한 @SpringBootTest 제거 (#97)

### DIFF
--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/AuthServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/AuthServiceTest.java
@@ -28,13 +28,14 @@ import gdsc.binaryho.imhere.mock.TestContainer;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
     private static final String UNIV_ID = "UNIV_ID";

--- a/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/auth/application/EmailVerificationServiceTest.java
@@ -11,9 +11,7 @@ import gdsc.binaryho.imhere.mock.TestContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 public class EmailVerificationServiceTest {
 
     private static final String EMAIL = "dlwlsgh4687@gmail.com";

--- a/src/test/java/gdsc/binaryho/imhere/security/principal/PrincipalDetailsServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/security/principal/PrincipalDetailsServiceTest.java
@@ -4,18 +4,20 @@ import static gdsc.binaryho.imhere.mock.fixture.MemberFixture.MOCK_STUDENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import gdsc.binaryho.imhere.core.member.infrastructure.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class PrincipalDetailsServiceTest {
 
     private PrincipalDetailsService principalDetailsService;
@@ -43,7 +45,7 @@ class PrincipalDetailsServiceTest {
 
     @Test
     void loadUserByUsername호출시_UnivId가_일치하는_유저가_없다면_예외를_던진다() {
-        given(memberRepository.findByUnivId("UNIV_ID")).willReturn(Optional.empty());
+        given(memberRepository.findByUnivId(any())).willReturn(Optional.empty());
 
         assertThatThrownBy(
             () -> principalDetailsService.loadUserByUsername("WRONG")


### PR DESCRIPTION
## What is this Pull Request about? 💬
서비스를 테스트 할 때 Mock을 사용해 Slice 테스트를 시도했던 이유가 
무거운 SpringBootTest를 올리지 않을 수 있으면 올리지 않으려던 시도였는데, Mock에 대한 이해가 부족해서 불필요한 @SpringBootTest를 사용하는 곳이 있었다. 단순히 Bean으로 등록하지 않은 Mock만 사용하는 경우 ExtendWith를 활용하면 SpringBootTest를 제거할 수 있었다.

이 밖에도 이번 코드 개선에서 서비스 테스트 자체에 대해 좀 더 고민할 필요가 있다고 느꼈다.
무거운 SpringBootTest를 돌리기 싫어서 Repository를 모킹하고 슬라이스 테스트를 하려 했는데,
Event 발생 검사나, Method 내부적으로 SecurityContext를 검사하는 테스트는 SpringBootTest가 붙어있다. 컨셉이 애매하다.
좀 더 고민해보자.

그리고 패키지도 한번 개선이 필요할 것 같다. 지금 현재 디렉토리 방식으로는 뭘 하고 싶은건지, 어디에 테스트가 있는지 조금 찾기 힘든 것 같다.