### PR TITLE
🛠️ [refactor] Presentation Layer 영속성 Layer 접근 제거 #95

### DIFF
--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -57,7 +57,7 @@ public class LectureService {
     }
 
     @Transactional(readOnly = true)
-    public LectureResponse getAllEnrollableLectures() {
+    public LectureResponse getAllLecturesForEnrollment() {
         List<Lecture> lectures = lectureRepository
             .findAllByLectureStateNot(LectureState.TERMINATED);
 

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/application/LectureService.java
@@ -57,6 +57,14 @@ public class LectureService {
     }
 
     @Transactional(readOnly = true)
+    public LectureResponse getAllEnrollableLectures() {
+        List<Lecture> lectures = lectureRepository
+            .findAllByLectureStateNot(LectureState.TERMINATED);
+
+        return LectureResponse.from(lectures);
+    }
+
+    @Transactional(readOnly = true)
     public LectureResponse getStudentLectures() {
         Member currentStudent = authenticationHelper.getCurrentMember();
         List<Lecture> studentLectures = findStudentLectures(currentStudent);

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/controller/LectureController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/controller/LectureController.java
@@ -1,15 +1,11 @@
 package gdsc.binaryho.imhere.core.lecture.controller;
 
-import gdsc.binaryho.imhere.core.lecture.LectureState;
 import gdsc.binaryho.imhere.core.lecture.application.LectureService;
-import gdsc.binaryho.imhere.core.lecture.domain.Lecture;
-import gdsc.binaryho.imhere.core.lecture.infrastructure.LectureRepository;
 import gdsc.binaryho.imhere.core.lecture.model.request.LectureCreateRequest;
 import gdsc.binaryho.imhere.core.lecture.model.response.AttendanceNumberResponse;
 import gdsc.binaryho.imhere.core.lecture.model.response.LectureResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -28,15 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class LectureController {
 
     private final LectureService lectureService;
-    private final LectureRepository lectureRepository;
 
     private static final String STATUS = "status=";
 
     @Operation(summary = "학생이 수강신청을 위해 개설된 모든 강의 리스트를 가져오는 API")
     @GetMapping
     public ResponseEntity<LectureResponse> getAllLectures() {
-        List<Lecture> lectures = lectureRepository.findAllByLectureStateNot(LectureState.TERMINATED);
-        return ResponseEntity.ok(LectureResponse.from(lectures));
+        return ResponseEntity.ok(
+            lectureService.getAllEnrollableLectures());
     }
 
     @Operation(summary = "로그인한 학생이 수강중인 강의 리스트를 가져오는 API")

--- a/src/main/java/gdsc/binaryho/imhere/core/lecture/controller/LectureController.java
+++ b/src/main/java/gdsc/binaryho/imhere/core/lecture/controller/LectureController.java
@@ -31,7 +31,7 @@ public class LectureController {
     @GetMapping
     public ResponseEntity<LectureResponse> getAllLectures() {
         return ResponseEntity.ok(
-            lectureService.getAllEnrollableLectures());
+            lectureService.getAllLecturesForEnrollment());
     }
 
     @Operation(summary = "로그인한 학생이 수강중인 강의 리스트를 가져오는 API")

--- a/src/test/java/gdsc/binaryho/imhere/core/lecture/application/LectureServiceTest.java
+++ b/src/test/java/gdsc/binaryho/imhere/core/lecture/application/LectureServiceTest.java
@@ -89,6 +89,30 @@ class LectureServiceTest {
     }
 
     @Test
+    void 수강신청이_가능한_강의_리스트를_빈_학생_리스트와_함께_가져올_수_있다() {
+        // given
+        given(lectureRepository
+            .findAllByLectureStateNot(LectureState.TERMINATED))
+            .willReturn(List.of(MOCK_LECTURE));
+
+        // when
+        LectureResponse lectureResponse = lectureService.getAllLecturesForEnrollment();
+        LectureInfo anyLectureInfo = lectureResponse.getLectureInfos()
+            .stream()
+            .findAny()
+            .get();
+
+        // then
+        assertAll(
+            () -> assertThat(MOCK_LECTURE.getId()).isEqualTo(anyLectureInfo.getLectureId()),
+            () -> assertThat(MOCK_LECTURE.getLectureName()).isEqualTo(anyLectureInfo.getLectureName()),
+            () -> assertThat(MOCK_LECTURE.getLecturerName()).isEqualTo(anyLectureInfo.getLecturerName()),
+            () -> assertThat(MOCK_LECTURE.getLectureState()).isEqualTo(anyLectureInfo.getLectureState()),
+            () -> assertThat(anyLectureInfo.getStudentInfos()).isEmpty()
+        );
+    }
+
+    @Test
     @MockSecurityContextMember(role = Role.LECTURER)
     void 강사는_강의를_만들_수_있다() {
         // given


### PR DESCRIPTION
## What is this Pull Request about? 💬
컨트롤러에서 따로 트랜잭션 없이 바로 Respoitory를 조회하는 로직을 하나 발견했다.
아마 극초반에 만들었던 코드인 것 같은데, 꼼꼼하게 살피지 못했다. <br> <br>

조회 코드를 Service로 이전시켜 트랜잭션을 적용해주고, 테스트를 작성한다.

<br>

## Key Changes 🔑
- Lecture Controller에서 Repository를 의존하는 부분을 트랜잭션이 포함된 Service 메서드로 이전
-수강신청 가능한 강의를 가져오는 테스트 코드 작성
