### PR TITLE
모니터링 툴 도입 #103

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	/* jasypt */
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 
+	/* monitoring */
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/gdsc/binaryho/imhere/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/binaryho/imhere/security/config/SecurityConfig.java
@@ -6,14 +6,20 @@ import gdsc.binaryho.imhere.security.filter.JwtAuthenticationFilter;
 import gdsc.binaryho.imhere.security.filter.JwtAuthorizationFilter;
 import gdsc.binaryho.imhere.security.jwt.TokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.channel.ChannelProcessingFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -32,6 +38,15 @@ public class SecurityConfig {
 
     private final TokenService tokenService;
 
+    @Value("${actuator.username}")
+    private String ACTUATOR_USERNAME;
+
+    @Value("${actuator.password}")
+    private String ACTUATOR_PASSWORD;
+
+    @Value("${actuator.role}")
+    private String ACTUATOR_ROLE;
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -44,6 +59,26 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Order(0)
+    public SecurityFilterChain filterChainForActuator(HttpSecurity http) throws Exception {
+        http
+            .requestMatchers()
+            .antMatchers("/system/actuator/**")
+
+            .and()
+            .httpBasic()
+
+            .and()
+            .userDetailsService(getActuatorUserDetailsService())
+
+            .cors().and()
+            .csrf().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        return http.build();
+    }
+
+    @Bean
+    @Order(1)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.sessionManagement()
@@ -56,7 +91,8 @@ public class SecurityConfig {
 
             .authorizeRequests()
 
-            .antMatchers("/login", "/logout", "/member/**", "/swagger*/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**")
+            .antMatchers("/login", "/logout", "/member/**",
+                "/swagger*/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**")
             .permitAll()
 
             .antMatchers("/api/admin/**")
@@ -67,9 +103,22 @@ public class SecurityConfig {
 
             .anyRequest().authenticated();
 
-        http.addFilterBefore(new JwtAuthenticationFilter(authenticationManager(authenticationConfiguration), tokenService), UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(new JwtAuthorizationFilter(authenticationManager(authenticationConfiguration), tokenService, memberRepository), BasicAuthenticationFilter.class);
+        http.addFilterBefore(new JwtAuthenticationFilter(
+            authenticationManager(authenticationConfiguration), tokenService), UsernamePasswordAuthenticationFilter.class);
+
+        http.addFilterBefore(new JwtAuthorizationFilter(
+            authenticationManager(authenticationConfiguration), tokenService, memberRepository), BasicAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    private UserDetailsService getActuatorUserDetailsService() {
+        String encodedPassword = passwordEncoder().encode(ACTUATOR_PASSWORD);
+        UserDetails userDetails = User.withUsername(ACTUATOR_USERNAME)
+            .password(encodedPassword)
+            .roles(ACTUATOR_ROLE)
+            .build();
+
+        return new InMemoryUserDetailsManager(userDetails);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,23 @@ jasypt:
   encryptor:
     bean: propertyEncryptor
   secret-key: ${JASYPT_ENCRYPTION_PASSWORD}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+      base-path: /system/actuator
+  endpoint:
+    health:
+      show-details: always
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+actuator:
+  username: ENC(QrTY/DXdFpQxYe6AEmcwjzwCiatUHeym)
+  password: ENC(x3q+XW2ivp/FlEpQnRJIGw2gAehDnLwk)
+  role: ENC(wjFg82eV2hT4ElsuFkon2KIi8apIzP31)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -71,3 +71,8 @@ jasypt:
   encryptor:
     bean: propertyEncryptor
   secret-key: ${JASYPT_ENCRYPTION_PASSWORD}
+
+actuator:
+  username: ENC(QrTY/DXdFpQxYe6AEmcwjzwCiatUHeym)
+  password: ENC(x3q+XW2ivp/FlEpQnRJIGw2gAehDnLwk)
+  role: ENC(wjFg82eV2hT4ElsuFkon2KIi8apIzP31)


### PR DESCRIPTION
## What is this Pull Request about? 💬

여러가지 문제들로 인해 -> #103 
모니터링 툴을 도입했다. 

원래는 단순히 의존성을 추가하고 사소한 설정만 하면 되는데, 시큐리티 때문에 조금 오래 걸렸다.

기본적으로 유저들은 JWT를 통해 인증하는데, 이 경우 토큰에 유효 기간이 있고, 매번 발급해 줘야 하므로, actuator 데이터 수집시엔 Basic Auth를 사용했다.

서버 다운의 원인을 꼭 파악해서 해결해보자. 그리고 다운시 알람이 오는 기능을 구현하는데에도 유용하게 쓰일 것이다.


