### PR TITLE
🚀 [feature] Continuous Deployment 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Deploy!
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl netcat openssh-client
+          sudo apt-get install -y curl netcat-openbsd openssh-client
           curl -L "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64" \
             -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy!
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    types: [ synchronize ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+name: Deploy!
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: 'gradle'
+
+      - name: Build with Gradle
+        env:
+          JASYPT_ENCRYPTION_PASSWORD: ${{ secrets.PROPERTY_ENCRYPTION_PASSWORD }}
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build --no-build-cache
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PASSWORD }}
+
+      - name: Build and push image
+        run: |
+          IMAGE="ghcr.io/${{ secrets.GHCR_USERNAME }}"
+          APP_NAME="imhere-server"
+          TAG="latest"
+          
+          docker build -t $IMAGE/$APP_NAME:$TAG .
+          docker push $IMAGE/$APP_NAME:$TAG
+
+      # TODO: scp로 docker-compose.yml 전달
+      - name: Deploy!
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl netcat openssh-client
+          curl -L "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64" \
+            -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+          nohup cloudflared access tcp \
+            --hostname "${{ secrets.SSH_HOST }}" \
+            --url "127.0.0.1:2222" \
+            --service-token-id "${{ secrets.CLOUDFLARE_TOKEN_ID }}" \
+            --service-token-secret "${{ secrets.CLOUDFLARE_TOKEN_SECRET }}" \
+            >/tmp/cloudflared.log 2>&1 &
+
+          for i in {1..20}; do
+            if nc -z 127.0.0.1 2222; then
+              echo "Connected!"
+              break
+            fi
+            echo "Waiting... ($i/20)"
+            sleep 1
+          done
+
+          echo "${{ secrets.SERVER_SSH_KEY }}" > /tmp/server_key
+          chmod 600 /tmp/server_key
+
+          ssh -t -o StrictHostKeyChecking=no \
+            -i /tmp/server_key \
+            -p 2222 \
+            ${{ secrets.SERVER_USERNAME }}@127.0.0.1 \
+            "cd imhere-server/docker-compose
+            
+            docker login ghcr.io -u '${{ secrets.GHCR_USERNAME }}' -p '${{ secrets.GHCR_PASSWORD }}'
+            
+            docker-compose down
+            docker-compose pull
+            docker-compose up -d --remove-orphans"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy!
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    types: [ synchronize ]
 
 jobs:
   deploy:

--- a/.github/workflows/pull-request-gradle-build-test.yml
+++ b/.github/workflows/pull-request-gradle-build-test.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Error Report Files를 Artifacts에 업로드
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: error_report_files
           path: error_report_files_*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+### Build ###
 HELP.md
 .gradle
 build/
@@ -45,3 +46,7 @@ out/
 /src/test/java/gdsc/binaryho/imhere/dev
 /src/main/java/gdsc/binaryho/imhere/dev
 /docker-compose**
+
+### secrets ###
+.*secrets
+.*env


### PR DESCRIPTION
## What is this Pull Request about? 💬
main branch push시 cd 구현

<br>

## Key Changes 🔑

1. 이미지 관리 방식을 GitHub Container Registry를 활용하도록 변경
    - Docker Hub의 private repo 갯수 초과했다.
    - Docker Hub API에 Rate Limit가 추가 되었다고 한다. (각종 제한들이 생기고 있다고 한다)
    - 써보고 싶다. 편리해 보여서
2. home server 연결을 위해 cloudflared tunnel ssh 연결
    - cloudflared tunnel ssh 연결은 아직 제대로 된 라이브러리가 없어서 깡으로 명령어를 쳐야 했다
    - 내가 만들어 버릴까? 고려해보장
3. TODO: docker-compose 전달 방식 고민 #131 
    - 현재 찾아본 래퍼런스들은 docker-compose를 미리 서버에 배치해두고, 그걸 활용한다.
    - 내겐 어색하게 느껴짐 docker-compose 또한 형상관리가 되어야 좋을것 같음.. 어떤 방법이건 간에 cd시에 docker-compose를 최신으로 업데이트 했으면 좋겠다.
    - 지금은 일단 급하게 할게 있으니, 이렇게 구현했지만 좋은 방법이라곤 전혀 안 느껴짐
    - cloudflare tunnel 사용지 scp 연결을 어떻게 하면 좋을지 알아볼 예정


