### PR TITLE
🛠️ [refactor] version up 'upload-artifact' to v4

### DIFF
--- a/.github/workflows/pull-request-gradle-build-test.yml
+++ b/.github/workflows/pull-request-gradle-build-test.yml
@@ -2,7 +2,7 @@ name : 풀 리퀘스트 Gradle 빌드 테스트
 
 on:
   pull_request:
-    types: [opened, reopen, synchronize, closed]
+    types: [opened, synchronize, closed]
 
 permissions: read-all
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Error Report Files를 Artifacts에 업로드
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: error_report_files
           path: error_report_files_*.tar.gz


### PR DESCRIPTION
## Key Changes 🔑
- CI시 발생하는 에러를 파일에 쓰기 위해 활용하는 'upload-artifact@v3'가 deprecate 되어 v4로 버전 업

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - PR 테스트 워크플로우의 트리거 조건이 간소화되어, 재오픈 시 자동 실행되지 않습니다.
  - 아티팩트 업로드 프로세스가 최신 버전으로 업데이트되어 보다 향상된 성능을 기대할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->